### PR TITLE
fix: solved negative values entered in the Warning level (m) and Dang…

### DIFF
--- a/apps/rahat-ui/src/sections/projects/aa-2/triggerStatement/edit.tsx
+++ b/apps/rahat-ui/src/sections/projects/aa-2/triggerStatement/edit.tsx
@@ -61,27 +61,41 @@ export default function EditTrigger() {
       forecastStatus: z.string().optional(),
     })
     .superRefine((data, ctx) => {
-      if (
-        data.source === 'DHM' &&
-        trigger?.phase?.name === 'ACTIVATION' &&
-        (!data.dangerLevel || data.dangerLevel.trim() === '')
-      ) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: ['dangerLevel'],
-          message: 'Danger Level is required',
-        });
+      if (data.source === 'DHM' && trigger?.phase?.name === 'ACTIVATION') {
+        if (!data.dangerLevel || data.dangerLevel.trim() === '') {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['dangerLevel'],
+            message: 'Danger Level is required',
+          });
+        } else if (
+          isNaN(Number(data.dangerLevel)) ||
+          Number(data.dangerLevel) <= 0
+        ) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['dangerLevel'],
+            message: 'Danger Level must be a positive number',
+          });
+        }
       }
-      if (
-        data.source === 'DHM' &&
-        trigger?.phase?.name === 'READINESS' &&
-        (!data.warningLevel || data.warningLevel.trim() === '')
-      ) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: ['warningLevel'],
-          message: 'Warning Level is required',
-        });
+      if (data.source === 'DHM' && trigger?.phase?.name === 'READINESS') {
+        if (!data.warningLevel || data.warningLevel.trim() === '') {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['warningLevel'],
+            message: 'Warning Level is required',
+          });
+        } else if (
+          isNaN(Number(data.warningLevel)) ||
+          Number(data.warningLevel) <= 0
+        ) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['warningLevel'],
+            message: 'Warning Level must be a positive number',
+          });
+        }
       }
     });
 


### PR DESCRIPTION
https://github.com/rahataid/rahat-project-aa/issues/567

- sloved negative values entered in the Warning level (m) and Danger level (m) fields are accepted without any validation error


<img width="798" alt="Screenshot 1947-03-21 at 11 18 17 AM" src="https://github.com/user-attachments/assets/ca2a4905-479b-4759-8650-24ef25da26d3" />
