### PR TITLE
fix: role protection on stakeholders group details page and its subpages

### DIFF
--- a/apps/rahat-ui/src/app/projects/aa/[id]/stakeholders/groups/add/page.tsx
+++ b/apps/rahat-ui/src/app/projects/aa/[id]/stakeholders/groups/add/page.tsx
@@ -1,9 +1,14 @@
 'use client';
 
+import { AARoles, RoleAuth } from '@rahat-ui/auth';
 import { AAUpdateOrAddStakeholdersGroup } from 'apps/rahat-ui/src/sections/projects/aa-2';
 
 const Page = () => {
-  return <AAUpdateOrAddStakeholdersGroup />;
+  return (
+    <RoleAuth roles={[AARoles.ADMIN, AARoles.MANAGER]}>
+      <AAUpdateOrAddStakeholdersGroup />;
+    </RoleAuth>
+  );
 };
 
 export default Page;

--- a/apps/rahat-ui/src/app/projects/aa/[id]/stakeholders/groups/edit/[editId]/page.tsx
+++ b/apps/rahat-ui/src/app/projects/aa/[id]/stakeholders/groups/edit/[editId]/page.tsx
@@ -1,9 +1,14 @@
 'use client';
 
+import { RoleAuth, AARoles } from '@rahat-ui/auth';
 import { AAUpdateOrAddStakeholdersGroup } from 'apps/rahat-ui/src/sections/projects/aa-2';
 
 const Page = () => {
-  return <AAUpdateOrAddStakeholdersGroup />;
+  return (
+    <RoleAuth roles={[AARoles.ADMIN, AARoles.MANAGER]}>
+      <AAUpdateOrAddStakeholdersGroup />;
+    </RoleAuth>
+  );
 };
 
 export default Page;

--- a/apps/rahat-ui/src/sections/projects/aa-2/stakeholders/columns.tsx
+++ b/apps/rahat-ui/src/sections/projects/aa-2/stakeholders/columns.tsx
@@ -165,18 +165,20 @@ export const useProjectStakeholdersGroupTableColumns = () => {
       enableHiding: false,
       cell: ({ row }) => {
         return (
-          <div className="flex items-center gap-2">
-            <Eye
-              className="hover:text-primary cursor-pointer"
-              size={16}
-              strokeWidth={1.5}
-              onClick={() =>
-                router.push(
-                  `/projects/aa/${id}/stakeholders/${row.original.uuid}?groupId=${groupId}`,
-                )
-              }
-            />
-          </div>
+          <RoleAuth roles={[AARoles.ADMIN, AARoles.MANAGER]} hasContent={false}>
+            <div className="flex items-center gap-2">
+              <Eye
+                className="hover:text-primary cursor-pointer"
+                size={16}
+                strokeWidth={1.5}
+                onClick={() =>
+                  router.push(
+                    `/projects/aa/${id}/stakeholders/${row.original.uuid}?groupId=${groupId}`,
+                  )
+                }
+              />
+            </div>
+          </RoleAuth>
         );
       },
     },

--- a/apps/rahat-ui/src/sections/projects/aa-2/stakeholders/stakeholders.groups.details.tsx
+++ b/apps/rahat-ui/src/sections/projects/aa-2/stakeholders/stakeholders.groups.details.tsx
@@ -21,6 +21,7 @@ import { UUID } from 'crypto';
 import { Plus, User } from 'lucide-react';
 import { useParams, useRouter } from 'next/navigation';
 import { useProjectStakeholdersGroupTableColumns } from './columns';
+import { AARoles, RoleAuth } from '@rahat-ui/auth';
 
 type Props = {};
 
@@ -107,18 +108,20 @@ const StakeholdersGroupsDetails = (props: Props) => {
             }
           />
 
-          <Button
-            variant="default"
-            type="button"
-            onClick={() =>
-              router.push(
-                `/projects/aa/${projectId}/stakeholders/groups/edit/${groupId}`,
-              )
-            }
-            className=""
-          >
-            <Plus size={18} className="mr-1" /> Add StakeHolder
-          </Button>
+          <RoleAuth roles={[AARoles.ADMIN, AARoles.MANAGER]} hasContent={false}>
+            <Button
+              variant="default"
+              type="button"
+              onClick={() =>
+                router.push(
+                  `/projects/aa/${projectId}/stakeholders/groups/edit/${groupId}`,
+                )
+              }
+              className=""
+            >
+              <Plus size={18} className="mr-1" /> Add StakeHolder
+            </Button>
+          </RoleAuth>
         </div>
 
         <DemoTable


### PR DESCRIPTION
- https://github.com/orgs/rahataid/projects/51/views/6?filterQuery=assignee%3A%40me&pane=issue&itemId=113927670&issue=rahataid%7Crahat-ui%7C1375
- fixed Project>> stakeholders group details page>> Hide +Add Stakeholder button and stakeholder view icon
- fixed path accessed via the +Add Stakeholder button on the Stakeholder Group Details page should be blocked and display an appropriate error message.