### PR TITLE
fix: daily monitoring(Gauge reading) feedback changes

### DIFF
--- a/apps/rahat-ui/src/sections/projects/aa-2/dataSources/components/dailyMonitoring/add/add.another.data.source.tsx
+++ b/apps/rahat-ui/src/sections/projects/aa-2/dataSources/components/dailyMonitoring/add/add.another.data.source.tsx
@@ -34,11 +34,13 @@ export default function AddAnotherDataSource({
     rainfallForecastSelectItems,
     rainfallSelectItems,
     floodForecastSelectItems,
-    gauageReadingStationSelectItems,
+    gaugeReadingStationSelectItems,
     possibility,
+    gaugeForecastDataSourceSelectItems,
   } = useSelectItems();
 
   const selectedDataSourceObjArray = form.watch('dataSource');
+  const selectedGaugeForecast = form.watch(fieldName('gaugeForecast'));
 
   const selectedSourceStringArray = selectedDataSourceObjArray?.map(
     (obj: any) => obj.source,
@@ -192,16 +194,25 @@ export default function AddAnotherDataSource({
           <>
             <SelectFormField
               form={form}
-              name={fieldName('station')}
-              label="Station"
-              placeholder="Select station"
-              selectItems={gauageReadingStationSelectItems}
+              name={fieldName('gaugeForecast')}
+              label="Forecast"
+              placeholder="Select forecast"
+              selectItems={gaugeForecastDataSourceSelectItems}
             />
             <InputFormField
               form={form}
               name={fieldName('gaugeReading')}
-              label="Gauge Reading (mm)"
+              label={`Gauge Reading ${
+                selectedGaugeForecast === 'riverWatch' ? '(m)' : '(mm)'
+              }`}
               placeholder="Enter gauge reading"
+            />
+            <SelectFormField
+              form={form}
+              name={fieldName('station')}
+              label="Station"
+              placeholder="Select station"
+              selectItems={gaugeReadingStationSelectItems}
             />
           </>
         );

--- a/apps/rahat-ui/src/sections/projects/aa-2/dataSources/components/dailyMonitoring/add/add.daily.monitoring.view.tsx
+++ b/apps/rahat-ui/src/sections/projects/aa-2/dataSources/components/dailyMonitoring/add/add.daily.monitoring.view.tsx
@@ -88,6 +88,7 @@ export default function AddDailyMonitoring() {
           //gauge Reading
           gaugeReading: z.string().optional(),
           station: z.string().optional(),
+          gaugeForecast: z.string().optional(),
         })
         .superRefine((data, ctx) => {
           const validateFields = (fields: (keyof typeof data)[]) => {
@@ -216,7 +217,7 @@ export default function AddDailyMonitoring() {
               break;
 
             case 'Gauge Reading':
-              validateFields(['gaugeReading', 'station']);
+              validateFields(['gaugeReading', 'station', 'gaugeForecast']);
               if (
                 data.gaugeReading === undefined ||
                 data.gaugeReading === null ||
@@ -227,7 +228,7 @@ export default function AddDailyMonitoring() {
                 ctx.addIssue({
                   code: z.ZodIssueCode.custom,
                   path: ['gaugeReading'],
-                  message: 'Gauage Reading  must be a positive number.',
+                  message: 'Gauge Reading  must be a positive number.',
                 });
               } else if (!/^\d+(\.\d+)?$/.test(String(data.gaugeReading))) {
                 ctx.addIssue({
@@ -346,6 +347,7 @@ export default function AddDailyMonitoring() {
             source: item.source,
             gaugeReading: item?.gaugeReading,
             station: item?.station,
+            gaugeForecast: item?.gaugeForecast,
           });
           break;
         default:

--- a/apps/rahat-ui/src/sections/projects/aa-2/dataSources/components/dailyMonitoring/edit/edit.daily.monitoring.view.tsx
+++ b/apps/rahat-ui/src/sections/projects/aa-2/dataSources/components/dailyMonitoring/edit/edit.daily.monitoring.view.tsx
@@ -136,6 +136,7 @@ export default function EditDailyMonitoring() {
               gaugeReading: item.gaugeReading || '',
               station: item.station,
               id: item.id,
+              gaugeForecast: item?.gaugeForecast,
             };
           default:
             return {
@@ -193,7 +194,7 @@ export default function EditDailyMonitoring() {
             .optional(),
           //Flash Flood Risk Monitoring
           status: z.string().optional(),
-
+          gaugeForecast: z.string().optional(),
           //gauge Reading
           gaugeReading: z.string().optional(),
 
@@ -323,7 +324,7 @@ export default function EditDailyMonitoring() {
               break;
 
             case 'Gauge Reading':
-              validateFields(['gaugeReading', 'station']);
+              validateFields(['gaugeReading', 'station', 'gaugeForecast']);
               if (
                 data.gaugeReading === undefined ||
                 data.gaugeReading === null ||
@@ -334,7 +335,7 @@ export default function EditDailyMonitoring() {
                 ctx.addIssue({
                   code: z.ZodIssueCode.custom,
                   path: ['gaugeReading'],
-                  message: 'Gauage Reading  must be a positive number.',
+                  message: 'Gauge Reading  must be a positive number.',
                 });
               } else if (!/^\d+(\.\d+)?$/.test(String(data.gaugeReading))) {
                 ctx.addIssue({
@@ -467,6 +468,7 @@ export default function EditDailyMonitoring() {
             gaugeReading: item?.gaugeReading,
             station: item?.station,
             id: item?.id,
+            gaugeForecast: item?.gaugeForecast,
           });
           break;
         default:

--- a/apps/rahat-ui/src/sections/projects/aa-2/dataSources/components/dailyMonitoring/useSelectItems.tsx
+++ b/apps/rahat-ui/src/sections/projects/aa-2/dataSources/components/dailyMonitoring/useSelectItems.tsx
@@ -70,7 +70,7 @@ export const useSelectItems = () => {
     { value: 'Extremely Heavy Rain', label: 'Extremely Heavy Rain' },
   ];
 
-  const gauageReadingStationSelectItems = [
+  const gaugeReadingStationSelectItems = [
     { value: 'Rangoon Ridge', label: 'Rangoon Ridge' },
     { value: 'Kolmoda Satyas ', label: 'Kolmoda Satyas ' },
   ];
@@ -78,6 +78,11 @@ export const useSelectItems = () => {
   const possibility = [
     { value: 'Yes', label: 'Yes' },
     { value: 'No', label: 'No' },
+  ];
+
+  const gaugeForecastDataSourceSelectItems = [
+    { value: 'rainfallWatch', label: 'Rainfall Watch' },
+    { value: 'riverWatch', label: 'River Watch' },
   ];
 
   return {
@@ -88,7 +93,8 @@ export const useSelectItems = () => {
     rainfallSelectItems,
     floodForecastSelectItems,
     rainfallForecastSelectItems,
-    gauageReadingStationSelectItems,
+    gaugeReadingStationSelectItems,
     possibility,
+    gaugeForecastDataSourceSelectItems,
   };
 };

--- a/apps/rahat-ui/src/utils/fieldLabelValidation.ts
+++ b/apps/rahat-ui/src/utils/fieldLabelValidation.ts
@@ -29,4 +29,5 @@ export const fieldLabels: Record<string, string> = {
   status: 'Status',
   gaugeReading: 'Gauge Reading',
   station: 'Station Name',
+  gaugeForecast: 'Gauge Forecast',
 };


### PR DESCRIPTION
https://github.com/orgs/rahataid/projects/51/views/26?pane=issue&itemId=117731128&issue=rahataid%7Crahat-project-aa%7C671

- Once Gauge Reading is selected as source when adding daily monitoring, Forecast filed should be added with dropdown(Rainfall Watch/ River Watch)
<img width="707" alt="Screenshot 1947-04-10 at 9 51 52 PM" src="https://github.com/user-attachments/assets/c04c791d-d673-4bc2-bea4-7ef9544a0914" />

- If Rainfall Watch is selected as forecast then Station and Gauge Reading(mm) should be displayed.
<img width="742" alt="Screenshot 1947-04-10 at 9 52 16 PM" src="https://github.com/user-attachments/assets/f25bad5d-5b52-44fc-99f0-1f723262855d" />

- If River Watch is selected as forecast then Station and Gauge Reading(m) should be displayed.
<img width="723" alt="Screenshot 1947-04-10 at 9 53 44 PM" src="https://github.com/user-attachments/assets/c13afada-b835-4179-abcb-545e9dd4eb23" />
