### PR TITLE
fix:'variations' field when updating field definitions

### DIFF
--- a/apps/community-tool-ui/src/sections/field-definitions/editFieldDefinition.tsx
+++ b/apps/community-tool-ui/src/sections/field-definitions/editFieldDefinition.tsx
@@ -89,6 +89,7 @@ export default function EditFieldDefinition({
       isActive: data?.isActive || false,
       isTargeting: data?.isTargeting || false,
       fieldPopulate: data?.fieldPopulate?.data || [],
+      variations: formattedVariations,
     });
   }, [
     data?.variations,


### PR DESCRIPTION
While updating the field definition, users will be  able tot update it without adding values in variation fields.