### PR TITLE
Redirect issue in activities page

### DIFF
--- a/apps/rahat-ui/src/sections/projects/aa-2/activities/components/communicationCard.tsx
+++ b/apps/rahat-ui/src/sections/projects/aa-2/activities/components/communicationCard.tsx
@@ -20,7 +20,7 @@ import { IconLabelBtn, SpinnerLoader } from 'apps/rahat-ui/src/common';
 import { Badge } from '@rahat-ui/shadcn/src/components/ui/badge';
 import { Button } from '@rahat-ui/shadcn/src/components/ui/button';
 import { useTriggerCommunication } from '@rahat-ui/query';
-import { useParams } from 'next/navigation';
+import { useParams, useSearchParams } from 'next/navigation';
 import { UUID } from 'crypto';
 import { SessionStatus } from '@rumsan/connect/src/types';
 import MessageWithToggle from './messageWithToggle';
@@ -74,6 +74,8 @@ export function CommunicationCard({
     }
   };
   const { id: projectId, activityID } = useParams();
+  const searchParams = useSearchParams();
+  const redirectTo = searchParams.get('from');
   const [loadingButtons, setLoadingButtons] = React.useState<string[]>([]);
   const trigger = useTriggerCommunication();
   const activityId = activityID as string;
@@ -108,7 +110,13 @@ export function CommunicationCard({
                 </h3>
                 {activityCommunication?.sessionStatus !== SessionStatus.NEW && (
                   <Link
-                    href={`/projects/aa/${projectId}/communication-logs/commsdetails/${activityCommunication?.communicationId}@${activityId}@${activityCommunication?.sessionId}?from=activities`}
+                    href={`/projects/aa/${projectId}/communication-logs/commsdetails/${
+                      activityCommunication?.communicationId
+                    }@${activityId}@${
+                      activityCommunication?.sessionId
+                    }?from=activities${
+                      redirectTo ? `&backFrom=${redirectTo}` : ''
+                    }`}
                     className="items-center justify-center hover:bg-gray-100"
                   >
                     <ArrowUpRight size={20} className="text-blue-800" />

--- a/apps/rahat-ui/src/sections/projects/aa-2/activities/components/phase-card.tsx
+++ b/apps/rahat-ui/src/sections/projects/aa-2/activities/components/phase-card.tsx
@@ -64,11 +64,7 @@ export default function PhaseCard({
   return (
     <Card
       className={(cn(' border-gray-300 shadow-sm p-4 rounded-xl '), className)}
-      onClick={() =>
-        router.push(
-          `/projects/aa/${ProjectId}/activities/${id}?from="mainPage"`,
-        )
-      }
+      onClick={() => router.push(`/projects/aa/${ProjectId}/activities/${id}`)}
     >
       <CardContent className="space-y-2 p-2">
         <div className="flex items-center justify-between ">

--- a/apps/rahat-ui/src/sections/projects/aa-2/activities/components/phase-content.tsx
+++ b/apps/rahat-ui/src/sections/projects/aa-2/activities/components/phase-content.tsx
@@ -59,7 +59,7 @@ export default function PhaseContent({
               className="w-5 h-5 cursor-pointer hover:shadow-md active:scale-95 focus:ring-2 focus:ring-blue-500 transition-transform"
               onClick={() => {
                 router.push(
-                  `/projects/aa/${projectID}/activities/list/${lowerTitle}?from=${lowerTitle}`,
+                  `/projects/aa/${projectID}/activities/list/${lowerTitle}`,
                 );
               }}
             />

--- a/apps/rahat-ui/src/sections/projects/aa-2/activities/details/activity.detail.page.view.tsx
+++ b/apps/rahat-ui/src/sections/projects/aa-2/activities/details/activity.detail.page.view.tsx
@@ -98,7 +98,9 @@ export default function ActivitiesDetailView() {
               Icon={RefreshCcw}
               handleClick={() =>
                 router.push(
-                  `/projects/aa/${projectId}/activities/${activityId}/update-status?from=detailPage`,
+                  `/projects/aa/${projectId}/activities/${activityId}/update-status?from=detailPage${
+                    redirectTo ? `&backFrom=${redirectTo}` : ''
+                  }`,
                 )
               }
               name="Update Status"

--- a/apps/rahat-ui/src/sections/projects/aa-2/activities/details/activity.detail.page.view.tsx
+++ b/apps/rahat-ui/src/sections/projects/aa-2/activities/details/activity.detail.page.view.tsx
@@ -84,7 +84,9 @@ export default function ActivitiesDetailView() {
                 confirmButtonText="Edit"
                 handleClick={() =>
                   router.push(
-                    `/projects/aa/${projectId}/activities/${activityId}/edit`,
+                    `/projects/aa/${projectId}/activities/${activityId}/edit?${
+                      redirectTo ? `&backFrom=${redirectTo}` : ''
+                    }`,
                   )
                 }
                 buttonClassName="rounded-sm w-full"

--- a/apps/rahat-ui/src/sections/projects/aa-2/activities/details/activity.detail.page.view.tsx
+++ b/apps/rahat-ui/src/sections/projects/aa-2/activities/details/activity.detail.page.view.tsx
@@ -23,8 +23,8 @@ export default function ActivitiesDetailView() {
     activityId,
   );
   const activitiesListPath = redirectTo
-    ? `/projects/aa/${projectId}/activities`
-    : `/projects/aa/${projectId}/activities/list/${activityDetail?.phase?.name.toLowerCase()}`;
+    ? `/projects/aa/${projectId}/activities/list/${redirectTo}`
+    : `/projects/aa/${projectId}/activities`;
 
   const deleteActivity = useDeleteActivities();
 

--- a/apps/rahat-ui/src/sections/projects/aa-2/activities/details/update.activity.status.tsx
+++ b/apps/rahat-ui/src/sections/projects/aa-2/activities/details/update.activity.status.tsx
@@ -52,6 +52,7 @@ export default function UpdateStatus() {
 
   const searchParams = useSearchParams();
   const redirectTo = searchParams.get('from');
+  const backFrom = searchParams.get('backFrom');
   const router = useRouter();
 
   const activitiesListPath = useMemo(() => {
@@ -60,7 +61,9 @@ export default function UpdateStatus() {
     }
 
     return redirectTo === 'detailPage'
-      ? `/projects/aa/${projectId}/activities/${activityId}`
+      ? `/projects/aa/${projectId}/activities/${activityId}${
+          backFrom ? `?from=${backFrom}` : ''
+        }`
       : `/projects/aa/${projectId}/activities/list/${redirectTo}`;
   }, [redirectTo, projectId, activityId]);
 

--- a/apps/rahat-ui/src/sections/projects/aa-2/activities/edit/activity.edit.view.tsx
+++ b/apps/rahat-ui/src/sections/projects/aa-2/activities/edit/activity.edit.view.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import { useParams, useRouter } from 'next/navigation';
+import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import { useFieldArray, useForm } from 'react-hook-form';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -171,6 +171,8 @@ import { DurationData } from '../add/add.activity.view';
 
 export default function EditActivity() {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const backFrom = searchParams.get('backFrom');
   const uploadFile = useUploadFile();
   const updateActivity = useUpdateActivities();
   const { id: projectID, activityID } = useParams();
@@ -501,7 +503,11 @@ export default function EditActivity() {
       <form onSubmit={form.handleSubmit(handleUpdateActivity)}>
         <div className="p-4">
           <div className=" mb-2 flex flex-col space-y-0">
-            <Back path={`/projects/aa/${projectID}/activities/${activityID}`} />
+            <Back
+              path={`/projects/aa/${projectID}/activities/${activityID}${
+                backFrom ? `?from=${backFrom}` : ''
+              }`}
+            />
 
             <div className="mt-4 flex justify-between items-center">
               <div>

--- a/apps/rahat-ui/src/sections/projects/aa-2/activities/list/useActivitiesTableColumn.tsx
+++ b/apps/rahat-ui/src/sections/projects/aa-2/activities/list/useActivitiesTableColumn.tsx
@@ -34,11 +34,8 @@ import { AARoles, RoleAuth } from '@rahat-ui/auth';
 // }
 
 export default function useActivitiesTableColumn() {
-  const { id: projectID } = useParams();
+  const { id: projectID, title } = useParams();
   const router = useRouter();
-
-  const searchParams = useSearchParams();
-  const redirectTo = searchParams.get('from');
 
   const handleEyeClick = (activityId: any) => {
     setPaginationToLocalStorage();
@@ -47,7 +44,7 @@ export default function useActivitiesTableColumn() {
 
   const handleUpdateStatusIconClick = (activityId: any) => {
     router.push(
-      `/projects/aa/${projectID}/activities/${activityId}/update-status?from=${redirectTo}`,
+      `/projects/aa/${projectID}/activities/${activityId}/update-status?from=${title}`,
     );
   };
 

--- a/apps/rahat-ui/src/sections/projects/aa-2/activities/list/useActivitiesTableColumn.tsx
+++ b/apps/rahat-ui/src/sections/projects/aa-2/activities/list/useActivitiesTableColumn.tsx
@@ -39,7 +39,9 @@ export default function useActivitiesTableColumn() {
 
   const handleEyeClick = (activityId: any) => {
     setPaginationToLocalStorage();
-    router.push(`/projects/aa/${projectID}/activities/${activityId}`);
+    router.push(
+      `/projects/aa/${projectID}/activities/${activityId}?from=${title}`,
+    );
   };
 
   const handleUpdateStatusIconClick = (activityId: any) => {

--- a/apps/rahat-ui/src/sections/projects/aa-2/communicationLog/details/comms.logs.detail.page.tsx
+++ b/apps/rahat-ui/src/sections/projects/aa-2/communicationLog/details/comms.logs.detail.page.tsx
@@ -64,6 +64,7 @@ export default function CommsLogsDetailPage() {
 
   const searchParams = useSearchParams();
   const from = searchParams.get('from');
+  const backFrom = searchParams.get('backFrom');
 
   const {
     pagination,
@@ -175,7 +176,9 @@ export default function CommsLogsDetailPage() {
 
   const path = useMemo(() => {
     return from === 'activities'
-      ? `/projects/aa/${projectID}/activities/${activityId}?from="mainPage"`
+      ? `/projects/aa/${projectID}/activities/${activityId}${
+          backFrom ? `?from=${backFrom}` : ''
+        }`
       : `/projects/aa/${projectID}/communication-logs/details/${activityId}`;
   }, [from, projectID, activityId]);
 


### PR DESCRIPTION
## Redirect Conditions Fixed
<img width="1124" height="702" alt="image" src="https://github.com/user-attachments/assets/8001044b-0da3-4bfc-833a-783113a02d3a" />

### Updated Conditions

<img width="1626" height="880" alt="image" src="https://github.com/user-attachments/assets/2c335c8b-b33a-4bd2-baf2-4aa3c2e0bb63" />

### Checked navigation conditions:
- [x]  activitiesPage -> updateActivities and updateActivities -> activitiesPage 
- [x]  activitiesPage -> activityDetails, activityDetails -> updateActivities and updateActivities -> activityDetails -> activitiesPage
- [x]  activitiesPage -> activitiesList -> updateActivities and updateActivities -> activitiesList -> activitiesPage
- [x] activitiesPage -> activitiesList -> activityDetails -> updateActivities and updateActivities -> activityDetails -> activitiesList -> updateActivities -> activitiesList -> activitiesPage

### New conditions added
- [x]  activitiesPage -> activityDetails -> communicationDetails and communicationDetails -> activityDetails -> activitiesPage
- [x]  activitiesList -> activityDetails -> communicationDetails and communicationDetails -> activityDetails -> activitiesList
- [x]  activitiesPage -> activityDetails -> editActivity and editActivity -> activityDetails -> activitiesPage
- [x]  activitiesList -> activityDetails -> editActivity and editActivity -> activityDetails -> activitiesList

## Bug Fixes 
- Fixed issue where the Activity List page title became null when navigating back from activitiesList to updateActivities, then back again to activitiesList, and repeating this flow.
-  Fixed issue where the Activity List page title was undefined when navigating from activitiesList to activityDetails and back, if backend data had not yet loaded.