### PR TITLE
880 title restrict group purpose change after assignment to project type aa

### DIFF
--- a/apps/rahat-ui/src/sections/beneficiary/groups/assignToProjectModal.tsx
+++ b/apps/rahat-ui/src/sections/beneficiary/groups/assignToProjectModal.tsx
@@ -103,6 +103,7 @@ export default function AssignBeneficiaryToProjectModal({
             </Button>
           </DialogClose>
           <Button
+            disabled={assignBeneficiaryGroup.isPending}
             onClick={handleAssignProject}
             type="button"
             variant="ghost"

--- a/apps/rahat-ui/src/sections/beneficiary/groups/beneficiary-groups.view.tsx
+++ b/apps/rahat-ui/src/sections/beneficiary/groups/beneficiary-groups.view.tsx
@@ -108,20 +108,21 @@ function BeneficiaryGroupsView() {
                             {i?.name ?? 'N/A'}
                           </p>
                           <div>
-                            {(i?.groupPurpose === GroupPurpose.BANK_TRANSFER ||
-                              i?.groupPurpose ===
-                                GroupPurpose.MOBILE_MONEY) && (
-                              <>
-                                {i?.groupPurpose ===
-                                  GroupPurpose.BANK_TRANSFER && (
-                                  <LandmarkIcon className="h-4 w-4 text-green-600" />
-                                )}
-                                {i?.groupPurpose ===
-                                  GroupPurpose.MOBILE_MONEY && (
-                                  <Phone className="h-4 w-4 text-green-600" />
-                                )}
-                              </>
-                            )}
+                            {i?.isGroupValidForAA &&
+                              (i?.groupPurpose === GroupPurpose.BANK_TRANSFER ||
+                                i?.groupPurpose ===
+                                  GroupPurpose.MOBILE_MONEY) && (
+                                <>
+                                  {i?.groupPurpose ===
+                                    GroupPurpose.BANK_TRANSFER && (
+                                    <LandmarkIcon className="h-4 w-4 text-green-600" />
+                                  )}
+                                  {i?.groupPurpose ===
+                                    GroupPurpose.MOBILE_MONEY && (
+                                    <Phone className="h-4 w-4 text-green-600" />
+                                  )}
+                                </>
+                              )}
                           </div>
                         </div>
 

--- a/apps/rahat-ui/src/sections/beneficiary/groups/groups.detail.tsx
+++ b/apps/rahat-ui/src/sections/beneficiary/groups/groups.detail.tsx
@@ -43,6 +43,13 @@ import { capitalizeFirstLetter } from 'apps/rahat-ui/src/utils';
 import { GroupPurpose } from 'apps/rahat-ui/src/constants/beneficiary.const';
 import LoaderRahat from 'apps/rahat-ui/src/components/LoaderRahat';
 
+type BenProjectType = {
+  Project: {
+    id: number;
+    name: string;
+  };
+};
+
 export default function GroupDetailView() {
   const { Id } = useParams() as { Id: UUID };
   const validateModal = useBoolean();
@@ -118,10 +125,16 @@ export default function GroupDetailView() {
       : '';
   }, [group?.data?.groupPurpose]);
 
+  const isAssignToAA = React.useMemo(() => {
+    return group?.data?.beneficiaryGroupProject?.some(
+      (benProject: BenProjectType) => benProject?.Project?.name === 'AA',
+    );
+  }, [group?.data?.beneficiaryGroupProject]);
+
   const assignedGroupId = React.useMemo(() => {
     return (
       group?.data?.beneficiaryGroupProject?.map(
-        (benProject: any) => benProject.Project.id,
+        (benProject: BenProjectType) => benProject.Project.id,
       ) ?? []
     );
   }, [group?.data?.beneficiaryGroupProject]);
@@ -215,7 +228,9 @@ export default function GroupDetailView() {
             <Button
               variant={'outline'}
               className={`gap-2 text-gray-700 rounded-sm ${
-                group?.data?.groupedBeneficiaries?.length === 0 && 'hidden'
+                (group?.data?.groupedBeneficiaries?.length === 0 ||
+                  isAssignToAA) &&
+                'hidden'
               }`}
               onClick={handleGroupPurposeClick}
             >

--- a/apps/rahat-ui/src/sections/beneficiary/groups/groups.detail.tsx
+++ b/apps/rahat-ui/src/sections/beneficiary/groups/groups.detail.tsx
@@ -47,6 +47,7 @@ type BenProjectType = {
   Project: {
     id: number;
     name: string;
+    type: string;
   };
 };
 
@@ -128,7 +129,7 @@ export default function GroupDetailView() {
   const isAssignToAA = React.useMemo(() => {
     return group?.data?.beneficiaryGroupProject?.some(
       (benProject: BenProjectType) =>
-        benProject?.Project?.name?.toLowerCase() === 'aa',
+        benProject?.Project?.type?.toLowerCase() === 'aa',
     );
   }, [group?.data?.beneficiaryGroupProject]);
 

--- a/apps/rahat-ui/src/sections/beneficiary/groups/groups.detail.tsx
+++ b/apps/rahat-ui/src/sections/beneficiary/groups/groups.detail.tsx
@@ -127,7 +127,8 @@ export default function GroupDetailView() {
 
   const isAssignToAA = React.useMemo(() => {
     return group?.data?.beneficiaryGroupProject?.some(
-      (benProject: BenProjectType) => benProject?.Project?.name === 'AA',
+      (benProject: BenProjectType) =>
+        benProject?.Project?.name?.toLowerCase() === 'aa',
     );
   }, [group?.data?.beneficiaryGroupProject]);
 

--- a/libs/query/src/lib/beneficiary/beneficiary.service.ts
+++ b/libs/query/src/lib/beneficiary/beneficiary.service.ts
@@ -340,6 +340,7 @@ export const useUpdateGroupPropose = () => {
       if (variables?.uuid) {
         await qc.invalidateQueries({
           queryKey: ['GET_BENEFICIARY_GROUP', variables.uuid],
+          exact: false,
         });
       }
       toast.fire({

--- a/libs/query/src/lib/beneficiary/beneficiary.service.ts
+++ b/libs/query/src/lib/beneficiary/beneficiary.service.ts
@@ -336,9 +336,9 @@ export const useUpdateGroupPropose = () => {
   return useMutation({
     mutationFn: (payload: any) =>
       updateGroupPropose(payload.uuid, payload.selectedPurpose),
-    onSuccess: (_data, variables) => {
+    onSuccess: async (_data, variables) => {
       if (variables?.uuid) {
-        qc.invalidateQueries({
+        await qc.invalidateQueries({
           queryKey: ['GET_BENEFICIARY_GROUP', variables.uuid],
         });
       }

--- a/libs/query/src/lib/projects/projects.service.ts
+++ b/libs/query/src/lib/projects/projects.service.ts
@@ -164,9 +164,11 @@ export const useAssignBenGroupToProject = () => {
       await Promise.all([
         queryClient.invalidateQueries({
           queryKey: ['GET_BENEFICIARY_GROUP', variables.beneficiaryGroupUUID],
+          exact: false,
         }),
         queryClient.invalidateQueries({
           queryKey: [TAGS.GET_BENEFICIARIES_GROUPS],
+          exact: false,
         }),
       ]);
 

--- a/libs/query/src/lib/projects/projects.service.ts
+++ b/libs/query/src/lib/projects/projects.service.ts
@@ -64,13 +64,12 @@ export const useGeneralAction = <T = any>() => {
     FormattedResponse<T>,
     Error,
     {
-     
       data: ProjectActions;
     },
     unknown
   >(
     {
-      mutationKey:  ['generalAction'],
+      mutationKey: ['generalAction'],
       mutationFn: projectClient.generalActions,
     },
     queryClient,
@@ -133,6 +132,7 @@ export const useAssignBenToProject = () => {
 
 export const useAssignBenGroupToProject = () => {
   const q = useProjectAction();
+  const queryClient = useQueryClient();
   const alert = useSwal();
   const toast = alert.mixin({
     toast: true,
@@ -148,7 +148,7 @@ export const useAssignBenGroupToProject = () => {
       projectUUID: UUID;
       beneficiaryGroupUUID: UUID;
     }) => {
-      return q.mutateAsync({
+      const response = await q.mutateAsync({
         uuid: projectUUID,
         data: {
           action: 'beneficiary.assign_group_to_project',
@@ -157,9 +157,13 @@ export const useAssignBenGroupToProject = () => {
           },
         },
       });
+      return response?.data;
     },
-    onSuccess: () => {
+    onSuccess: async (_data, variables) => {
       q.reset();
+      await queryClient.invalidateQueries({
+        queryKey: ['GET_BENEFICIARY_GROUP', variables.beneficiaryGroupUUID],
+      });
       toast.fire({
         title: 'Beneficiary group assigned Successfully',
         icon: 'success',

--- a/libs/query/src/lib/projects/projects.service.ts
+++ b/libs/query/src/lib/projects/projects.service.ts
@@ -161,9 +161,15 @@ export const useAssignBenGroupToProject = () => {
     },
     onSuccess: async (_data, variables) => {
       q.reset();
-      await queryClient.invalidateQueries({
-        queryKey: ['GET_BENEFICIARY_GROUP', variables.beneficiaryGroupUUID],
-      });
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: ['GET_BENEFICIARY_GROUP', variables.beneficiaryGroupUUID],
+        }),
+        queryClient.invalidateQueries({
+          queryKey: [TAGS.GET_BENEFICIARIES_GROUPS],
+        }),
+      ]);
+
       toast.fire({
         title: 'Beneficiary group assigned Successfully',
         icon: 'success',


### PR DESCRIPTION
https://github.com/orgs/rahataid/projects/51/views/6?filterQuery=assignee%3A%40me&pane=issue&itemId=3337720955&issue=rahataid%7Crahat-project-aa%7C881
https://github.com/orgs/rahataid/projects/51/views/6?filterQuery=assignee%3A%40me&pane=issue&itemId=125248952&issue=rahataid%7Crahat-project-aa%7C883
https://github.com/orgs/rahataid/projects/51/views/6?filterQuery=assignee%3A%40me&pane=issue&itemId=125114879&issue=rahataid%7Crahat-project-aa%7C880

- Disable the Assign button when the group is already assigned to a project.
- Show the icon in the beneficiary group list page only if the group purpose is verified.
- Refetch all beneficiary group data after assigning a group to a project.
- Hide the Change Group button once the group is assigned to the AA project.