### PR TITLE
fix: resolved grievances list window while change the tab

### DIFF
--- a/apps/rahat-ui/src/sections/projects/aa-2/grievances/details/grievance.detail.split.view.tsx
+++ b/apps/rahat-ui/src/sections/projects/aa-2/grievances/details/grievance.detail.split.view.tsx
@@ -21,6 +21,7 @@ import { useState, useEffect } from 'react';
 import { PriorityChip, TypeChip } from '../components';
 import { TooltipText } from 'apps/rahat-ui/src/components/tootltip.text';
 import TooltipComponent from 'apps/rahat-ui/src/components/tooltip';
+import { useSecondPanel } from 'apps/rahat-ui/src/providers/second-panel-provider';
 
 type IProps = {
   grievance: {
@@ -45,17 +46,17 @@ type IProps = {
     closedAt?: string;
     resolvedAt?: string;
   };
-  closeSecondPanel: VoidFunction;
 };
 
 export default function GrievanceDetailSplitView({
   grievance: initialGrievance,
-  closeSecondPanel,
 }: IProps) {
   const router = useRouter();
   const { id: projectId } = useParams() as { id: UUID };
   const searchParams = useSearchParams();
   const redirectToHomeTab = searchParams.get('tab') || 'list';
+
+  const { closeSecondPanel } = useSecondPanel();
 
   // Fetch latest grievance details to ensure data is up-to-date
   const { data: grievanceDetails, refetch: refetchGrievanceDetails } =
@@ -85,14 +86,12 @@ export default function GrievanceDetailSplitView({
     router.push(
       `/projects/aa/${projectId}/grievances/${grievance?.uuid}/edit?from=split&tab=${redirectToHomeTab}`,
     );
-    closeSecondPanel();
   };
 
   const handleViewFull = () => {
     router.push(
       `/projects/aa/${projectId}/grievances/${grievance?.uuid}?tab=${redirectToHomeTab}`,
     );
-    closeSecondPanel();
   };
 
   const handleStatusChange = (value: string) => {

--- a/apps/rahat-ui/src/sections/projects/aa-2/grievances/list/columns.tsx
+++ b/apps/rahat-ui/src/sections/projects/aa-2/grievances/list/columns.tsx
@@ -21,12 +21,7 @@ export const useGrievancesTableColumns = () => {
   const { setSecondPanelComponent } = useSecondPanel();
 
   const openSplitDetailView = (grievance: any) => {
-    setSecondPanelComponent(
-      <GrievanceDetailSplitView
-        grievance={grievance}
-        closeSecondPanel={() => setSecondPanelComponent(null)}
-      />,
-    );
+    setSecondPanelComponent(<GrievanceDetailSplitView grievance={grievance} />);
   };
 
   const columns: ColumnDef<any>[] = [

--- a/apps/rahat-ui/src/sections/projects/aa-2/grievances/list/grievances.tabs.tsx
+++ b/apps/rahat-ui/src/sections/projects/aa-2/grievances/list/grievances.tabs.tsx
@@ -7,12 +7,26 @@ import {
 } from 'libs/shadcn/src/components/ui/tabs';
 import GrievanceOverview from './grievances.overview';
 import GrievancesTable from './grievances.table';
+import { useSecondPanel } from 'apps/rahat-ui/src/providers/second-panel-provider';
 
 export default function GrievancesTabs() {
+  const { closeSecondPanel } = useSecondPanel();
   const { activeTab, setActiveTab } = useActiveTab('overview');
+
+  const handleTabChange = (value: string) => {
+    if (value === 'overview') {
+      closeSecondPanel();
+    }
+    setActiveTab(value);
+  };
+
   return (
     <div>
-      <Tabs defaultValue={activeTab} onValueChange={setActiveTab}>
+      <Tabs
+        defaultValue={activeTab}
+        value={activeTab}
+        onValueChange={handleTabChange}
+      >
         <TabsList className="border bg-secondary rounded pb-2">
           <TabsTrigger
             className="w-full data-[state=active]:bg-white"


### PR DESCRIPTION
- Resolved an issue where the grievances list side modal was not closing when changing the tab configuration

- Resolved an issue where clicking the grievances edit or details button first closed the side modal and then redirected to the respective page