### PR TITLE
2028 activity log filter not working for audience and status in communication logs

### DIFF
--- a/apps/rahat-ui/src/sections/projects/aa-2/communicationLog/details/comms.logs.detail.page.tsx
+++ b/apps/rahat-ui/src/sections/projects/aa-2/communicationLog/details/comms.logs.detail.page.tsx
@@ -3,7 +3,6 @@ import {
   useListAllTransports,
   useListSessionLogs,
   usePagination,
-  useRetryFailedBroadcast,
   useSessionBroadCastCount,
   useSessionRetryFailed,
   useSingleActivity,
@@ -35,7 +34,6 @@ import { useDebounce } from 'apps/rahat-ui/src/utils/useDebouncehooks';
 import { UUID } from 'crypto';
 import {
   CloudDownload,
-  LucideIcon,
   Mail,
   RefreshCcw,
   Mic,
@@ -43,7 +41,7 @@ import {
 } from 'lucide-react';
 
 import { useParams, useSearchParams } from 'next/navigation';
-import React, { useMemo, useState } from 'react';
+import React, { useMemo } from 'react';
 import { toast } from 'react-toastify';
 
 import { exportAllLogs, exportFailedLogs } from './comms.logs.export.utils';

--- a/apps/rahat-ui/src/sections/projects/aa-2/communicationLog/details/comms.logs.detail.page.tsx
+++ b/apps/rahat-ui/src/sections/projects/aa-2/communicationLog/details/comms.logs.detail.page.tsx
@@ -209,7 +209,7 @@ export default function CommsLogsDetailPage() {
 
   const handleSearch = React.useCallback(
     (event: React.ChangeEvent<HTMLInputElement> | null, key: string) => {
-      const value = event?.target?.value ?? '';
+      const value = (event?.target?.value ?? '').trim();
       setFilters({ ...filters, [key]: value });
     },
     [filters],

--- a/libs/query/src/lib/aa/communication/communication.service.ts
+++ b/libs/query/src/lib/aa/communication/communication.service.ts
@@ -13,7 +13,7 @@ export const useGetCommunicationLogs = (
   const q = useProjectAction();
 
   const query = useQuery({
-    queryKey: ['communicationlogs', uuid, communicationId],
+    queryKey: ['communicationlogs', uuid, communicationId, activityId],
     queryFn: async () => {
       const mutate = await q.mutateAsync({
         uuid,

--- a/libs/query/src/lib/new-comms/new-comms.query.tsx
+++ b/libs/query/src/lib/new-comms/new-comms.query.tsx
@@ -26,7 +26,7 @@ export const useListSessionLogs = (sessionId: string, payload: any) => {
     queryFn: () =>
       newCommunicationService.session.listBroadcasts(sessionId, payload),
 
-    queryKey: ['TAGS.NEW_COMMS.LIST_TRANSPORTS', payload],
+    queryKey: ['TAGS.NEW_COMMS.LIST_TRANSPORTS', payload, sessionId],
     staleTime: 60 * 60 * 1000, // 1 hour
   });
   return query;


### PR DESCRIPTION
- filter issue fixed(removing white space)
<img width="1185" height="754" alt="Screenshot 2026-04-28 at 17 03 02" src="https://github.com/user-attachments/assets/daff310c-5b96-4397-bab7-e0d82e7cef72" />

- refetching new data on tabs change
<img width="1185" height="810" alt="Screenshot 2026-04-28 at 17 01 35" src="https://github.com/user-attachments/assets/5f6f46b8-b026-4d06-b6eb-687e458bd5d2" />
