### PR TITLE
preserve raw string values for csv imports

### DIFF
--- a/apps/community-tool-ui/src/sections/beneficiary/import/Beneficiary.tsx
+++ b/apps/community-tool-ui/src/sections/beneficiary/import/Beneficiary.tsx
@@ -174,13 +174,17 @@ export default function BenImp({ fieldDefinitions }: IProps) {
     const fileName = formatNameString(files[0].name);
     if (!files.length) return;
     const reader = new FileReader();
+    const file = files[0];
+    const isCsv = file.name.toLowerCase().endsWith('.csv');
+
     reader.onload = (e: any) => {
       const data = e.target.result;
-      const workbook = xlsx.read(data, { type: 'array' });
+      const workbook = xlsx.read(data, { type: 'array', raw: isCsv });
       const sheetName = workbook.SheetNames[0];
       const worksheet = workbook.Sheets[sheetName];
       const json = xlsx.utils.sheet_to_json(worksheet, {
         defval: '',
+        raw: isCsv
       }) as any;
       const sanitized = removeFieldsWithUnderscore(json || []);
       setRawData(sanitized);


### PR DESCRIPTION
## Description
This PR fixes an issue in the beneficiary import process where long numeric-looking strings (like `walletAddress`) were being incorrectly parsed as numbers during CSV uploads. This automatic conversion led to scientific notation formatting (e.g., `1.23e+45`) and precision loss, making the addresses invalid.

## Changes
- Updated `handleFileSelect` to detect if the uploaded file is a `.csv`.
- Applied `raw: true` to `xlsx.read` and `xlsx.utils.sheet_to_json` specifically for CSV files.
- This ensures that all data from CSVs is treated as raw strings, preserving the exact text of wallet addresses and other identifiers.
