### PR TITLE
redirect  to back page

### DIFF
--- a/apps/rahat-ui/src/sections/projects/aa-2/vendor/tables/inkind.beneficiary.list.tsx
+++ b/apps/rahat-ui/src/sections/projects/aa-2/vendor/tables/inkind.beneficiary.list.tsx
@@ -96,7 +96,9 @@ export default function InKindBeneficiaryList() {
           iconStyle="hover:text-primary cursor-pointer"
           handleOnClick={() => {
             router.push(
-              `/projects/aa/${id}/beneficiary/${row.original.beneficiary.uuid}`,
+              `/projects/aa/${id}/beneficiary/${row.original.beneficiary.uuid}?vendorId=${vendorId}&tab=inKindBeneficiaryList&subTab=${activeTab}#pagination=${encodeURIComponent(
+                JSON.stringify(pagination),
+              )}`,
             );
           }}
         />


### PR DESCRIPTION
- Issue fixed - When navigating from the Vendor Details page → In-kind Beneficiary List → Walk-in Beneficiary, clicking the back arrow incorrectly redirects the user to the Project Beneficiary page instead of returning to the Vendor page.
[video](https://www.awesomescreenshot.com/video/52583738?key=a32c3ff2a0e3c403c21c59f5dd0ba1e6)