### PR TITLE
2209 hide txhash label when transaction hash is not available in trigger details page

### DIFF
--- a/apps/rahat-ui/src/sections/projects/aa-2/triggerStatement/detail.tsx
+++ b/apps/rahat-ui/src/sections/projects/aa-2/triggerStatement/detail.tsx
@@ -64,8 +64,6 @@ export default function TriggerStatementDetail() {
     projectInfo?.value?.project_type || '',
   );
 
-  console.log('trigger data', trigger);
-
   const phase = trigger?.phase?.name;
   const source = trigger?.source;
   const txnUrl = getExplorerUrl({

--- a/apps/rahat-ui/src/sections/projects/aa-2/triggerStatement/detail.tsx
+++ b/apps/rahat-ui/src/sections/projects/aa-2/triggerStatement/detail.tsx
@@ -63,6 +63,8 @@ export default function TriggerStatementDetail() {
     projectInfo?.value?.project_type || '',
   );
 
+console.log("trigger data", trigger);
+
   const phase = trigger?.phase?.name;
   const source = trigger?.source;
   const txnUrl = getExplorerUrl({
@@ -234,9 +236,9 @@ export default function TriggerStatementDetail() {
               <Badge>{trigger?.isMandatory ? 'Mandatory' : 'Optional'}</Badge>
             </div>
 
-            <div className="flex-1 min-w-0">
-              <p className="mb-1">TxHash</p>
-              {trigger?.transactionHash ? (
+            {trigger?.transactionHash && (
+              <div className="flex-1 min-w-0">
+                <p className="mb-1">TxHash</p>
                 <Link
                   href={txnUrl || '#'}
                   target="_blank"
@@ -244,10 +246,8 @@ export default function TriggerStatementDetail() {
                 >
                   {trigger.transactionHash}
                 </Link>
-              ) : (
-                <p className="text-red-500">N/A</p>
-              )}
-            </div>
+              </div>
+            )}
             {trigger?.createdBy && (
               <div>
                 <p className="mb-1">Created By</p>

--- a/apps/rahat-ui/src/sections/projects/aa-2/triggerStatement/detail.tsx
+++ b/apps/rahat-ui/src/sections/projects/aa-2/triggerStatement/detail.tsx
@@ -32,6 +32,7 @@ import { getExplorerUrl } from 'apps/rahat-ui/src/utils';
 import { AlertCircleIcon } from 'lucide-react';
 import TooltipWrapper from 'apps/rahat-ui/src/components/tooltip.wrapper';
 import { getStationTitle } from 'apps/rahat-ui/src/utils/getStationTitle';
+import { TruncatedCell } from '../stakeholders/component/TruncatedCell';
 
 export default function TriggerStatementDetail() {
   const router = useRouter();
@@ -63,7 +64,7 @@ export default function TriggerStatementDetail() {
     projectInfo?.value?.project_type || '',
   );
 
-console.log("trigger data", trigger);
+  console.log('trigger data', trigger);
 
   const phase = trigger?.phase?.name;
   const source = trigger?.source;
@@ -244,7 +245,10 @@ console.log("trigger data", trigger);
                   target="_blank"
                   className="block overflow-hidden text-ellipsis whitespace-nowrap text-blue-500 hover:underline"
                 >
-                  {trigger.transactionHash}
+                  <TruncatedCell
+                    text={trigger.transactionHash || 'N/A'}
+                    maxLength={10}
+                  />
                 </Link>
               </div>
             )}


### PR DESCRIPTION
- Improved the Trigger Details(Automated & Manual trigger details page) UI by conditionally rendering the TxHash label and value only when a valid transaction hash is available from the backend response.
https://github.com/rahataid/rahat-ui/issues/2209