### PR TITLE
2276 remove unnecessary selected field from offline in kind assignment form

### DIFF
--- a/apps/rahat-ui/src/sections/projects/aa-2/inkindManagement/forms/assign.inkind.form.tsx
+++ b/apps/rahat-ui/src/sections/projects/aa-2/inkindManagement/forms/assign.inkind.form.tsx
@@ -179,7 +179,7 @@ export default function AssignInkindForm({ onNext }: Props) {
                       >
                         {field.value
                           ? inkindItems.find((i) => i.uuid === field.value)
-                              ?.name
+                            ?.name
                           : 'Select InKind Item'}
                         <ChevronDown className="opacity-50" />
                       </Button>
@@ -328,14 +328,7 @@ export default function AssignInkindForm({ onNext }: Props) {
                     <FormLabel className="mt-1 text-base font-medium">
                       Select Vendor
                     </FormLabel>
-                    {selectedVendor && (
-                      <p className="text-xs text-muted-foreground">
-                        Selected:{' '}
-                        <span className="font-semibold text-primary">
-                          {selectedVendor.inkind?.name}
-                        </span>
-                      </p>
-                    )}
+
                   </div>
                   <Popover open={vendorOpen} onOpenChange={setVendorOpen}>
                     <PopoverTrigger asChild>


### PR DESCRIPTION
## 🔗 Related Issue

<!-- Link issue (if any) -->
- https://github.com/rahataid/rahat-ui/issues/2276

- [x] Added issue link

## 📌 Description

<!-- What does this PR do? Explain clearly -->

- Issue :In the In-Kind Management module, when a user switches to Offline Mode and proceeds with assigning an in-kind item, an additional field labeled "Selected" is displayed in the assignment form after selecting the beneficiary, in-kind type, and vendor.
- This PR  fixes  the above mentioned issue.

---

## ✅ Checklist

- [x] No `console.log` or debug code left
- [ ] Proper error handling implemented
- [ ] Loading states handled (if needed)
- [ ] API calls handled safely
- [x] No unnecessary code or comments
- [x] Self-reviewed code for logic, edge cases, and potential issues

---

## 🎯 Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] UI update
- [ ] Refactor
- [ ] Performance improvement

---

## 📸 Before / After

### Before

## <!-- Add screenshots -->
<img width="1258" height="831" alt="issue-image-before" src="https://github.com/user-attachments/assets/a0583a56-8a86-4cad-8983-4de54705bbb4" />

### After

## <!-- Add screenshots -->
<img width="1258" height="828" alt="issue-image-after" src="https://github.com/user-attachments/assets/3ff15f4b-8c63-46fc-a955-6910aa2c6174" />

---

## 🧪 How to Test

<!-- Steps to test this PR -->

1. Go to Inkind management page
2. Click on Assign Inkind button then a form opens
3. Switch the Assign mode to offline and select the  provided field  then there you will see `Selected:` which is mistakenly placed in the code

---

## ⚠️ Notes for Reviewer

<!-- Anything special reviewer should know -->

-  Assign Mode must be in `offline` mode 
