### PR TITLE
Fix cache query key and generate hydrograph discharge image

### DIFF
--- a/apps/rahat-ui/src/sections/projects/aa-2/dataSources/components/dhm/info.tsx
+++ b/apps/rahat-ui/src/sections/projects/aa-2/dataSources/components/dhm/info.tsx
@@ -16,6 +16,7 @@ interface InfoProp {
     elevation: number;
     district: string;
     name: string;
+    basin: string;
     steady: string;
     status: string;
     waterLevel: { value: number; datetime: string };
@@ -60,9 +61,9 @@ export function Info({ riverWatch, updatedAt }: InfoProp) {
       <div className="p-4 rounded-sm border shadow w-full">
         <div className="flex justify-between gap-4">
           <Heading
-            title={riverWatch?.name}
+            title={riverWatch?.basin}
             titleStyle="text-xl/6 font-semibold"
-            description={riverWatch?.description}
+            description={riverWatch?.name}
             updatedAt={updatedAt}
           />
           <div>

--- a/apps/rahat-ui/src/sections/projects/aa-2/dataSources/components/dhm/river.watch.view.tsx
+++ b/apps/rahat-ui/src/sections/projects/aa-2/dataSources/components/dhm/river.watch.view.tsx
@@ -93,9 +93,9 @@ export default function RiverWatchView() {
         <div className="w-full">
           <div className="flex justify-between gap-4">
             <Heading
-              title={primaryRiverWatchInfo?.name}
+              title={primaryRiverWatchInfo?.basin}
               titleStyle="text-xl/6 font-semibold"
-              description={primaryRiverWatchInfo?.basin}
+              description={primaryRiverWatchInfo?.name}
               updatedAt={updatedAt}
             />
             <div>

--- a/apps/rahat-ui/src/sections/projects/aa-2/dataSources/components/glofas/glofas.hydrograph.chart.tsx
+++ b/apps/rahat-ui/src/sections/projects/aa-2/dataSources/components/glofas/glofas.hydrograph.chart.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import {
+  ResponsiveContainer,
+  ComposedChart,
+  Area,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+} from 'recharts';
+import { dateFormat } from 'apps/rahat-ui/src/utils/dateFormate';
+
+interface IGlofasHydrographChartProps {
+  series: { date: string; min: number; max: number; mean: number }[];
+}
+
+const GlofasHydrographChart = ({ series }: IGlofasHydrographChartProps) => {
+  if (!series?.length) return null;
+
+  const chartData = series.map((d) => ({
+    ...d,
+    date: dateFormat(d.date, 'MMM dd'),
+    range: [d.min, d.max],
+  }));
+
+  return (
+    <div className="bg-card overflow-hidden p-4 border shadow rounded-sm mt-4">
+      <h1 className="font-semibold text-lg mb-4">Discharge Forecast (m³/s)</h1>
+      <ResponsiveContainer width="100%" height={400}>
+        <ComposedChart data={chartData}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="date" tick={{ fontSize: 12 }} />
+          <YAxis tick={{ fontSize: 12 }} />
+          <Tooltip />
+          <Legend />
+          <Area
+            dataKey="range"
+            name="Min-Max range"
+            stroke="none"
+            fill="#93c5fd"
+            fillOpacity={0.4}
+          />
+          <Line
+            dataKey="mean"
+            name="Mean discharge"
+            stroke="#1d4ed8"
+            dot={false}
+            strokeWidth={2}
+          />
+        </ComposedChart>
+      </ResponsiveContainer>
+    </div>
+  );
+};
+
+export default GlofasHydrographChart;

--- a/apps/rahat-ui/src/sections/projects/aa-2/dataSources/components/glofas/glofas.periodData.table.tsx
+++ b/apps/rahat-ui/src/sections/projects/aa-2/dataSources/components/glofas/glofas.periodData.table.tsx
@@ -21,7 +21,7 @@ const GlofasPeriodDataTable = ({
       <div className="flex justify-between items-center mb-4">
         <h1 className="font-semibold text-lg capitalize">{title}</h1>
       </div>
-      <div className="overflow-auto">
+      <div className="overflow-auto pb-2">
         <table className="min-w-full bg-white border border-gray-200">
           <thead>
             <tr>

--- a/apps/rahat-ui/src/sections/projects/aa-2/dataSources/components/glofas/glofasDetials/main.tsx
+++ b/apps/rahat-ui/src/sections/projects/aa-2/dataSources/components/glofas/glofasDetials/main.tsx
@@ -6,8 +6,8 @@ import {
   useProjectSettingsStore,
 } from '@rahat-ui/query';
 import { UUID } from 'crypto';
-import Image from 'next/image';
 import GlofasPeriodDataTable from '../glofas.periodData.table';
+import GlofasHydrographChart from '../glofas.hydrograph.chart';
 import { Back, Heading, NoResult, TableLoader } from 'apps/rahat-ui/src/common';
 import { useParams } from 'next/navigation';
 import { ScrollArea } from '@rahat-ui/shadcn/src/components/ui/scroll-area';
@@ -61,16 +61,7 @@ const GlofasDetails = () => {
           title={`ECMWF-ENS > ${returnPeriod} RP`}
         />
 
-        <div className="bg-card overflow-hidden p-4 border shadow rounded-sm mt-4">
-          <div className="relative w-full min-h-[600px] overflow-hidden">
-            <Image
-              src={data?.info?.hydrographImageUrl}
-              alt="hydrograph-chart"
-              fill
-              className="object-cover"
-            />
-          </div>
-        </div>
+        <GlofasHydrographChart series={data?.info?.dischargeSeries} />
       </ScrollArea>
     </div>
   );

--- a/libs/query/src/lib/aa/trigger-statements/trigger-statements.service.ts
+++ b/libs/query/src/lib/aa/trigger-statements/trigger-statements.service.ts
@@ -654,7 +654,7 @@ export const useGlofasProbFloodDetails = (uuid: UUID, payload: any) => {
   });
 
   const query = useQuery({
-    queryKey: ['glofas_prob_flood_details', uuid],
+    queryKey: ['glofas_prob_flood_details', uuid, payload?.returnPeriod],
     queryFn: async () => {
       try {
         const mutate = await q.mutateAsync({


### PR DESCRIPTION
## 🔗 Related Issue
https://github.com/rahataid/rahat-ui/issues/2275

## 📌 Description

Fixes GLOFAS data caching and missing hydrograph chart:
- React Query cache key for `useGlofasProbFloodDetails` was missing `returnPeriod`, so switching between 2/5/20-year return periods reused stale cached data.
- Hydrograph chart used a static `hydrographImageUrl` that the API no longer returns; replaced with a `recharts`-based chart (mean line + min/max band) driven by the new `dischargeSeries` field.
- Squeezed table scrollbar spacing so it doesn't overlap content on smaller screens.

---

## ✅ Checklist

- [x] No `console.log` or debug code left
- [x] Proper error handling implemented
- [x] Loading states handled (if needed)
- [x] API calls handled safely
- [x] No unnecessary code or comments
- [x] Self-reviewed code for logic, edge cases, and potential issues

---

## 🎯 Type of Change

- [x] Bug fix
- [x] UI update

---

## 📸 Before / After

### Before
Hydrograph showed a stale/broken static image; switching return periods kept old table data.
<img width="1189" height="605" alt="image" src="https://github.com/user-attachments/assets/d8188138-ff0c-4247-9da4-ffe6bbda181e" />


### After
Hydrograph renders a discharge forecast chart (mean + min/max range) from live data; switching return periods refetches correctly.
<img width="1206" height="526" alt="image" src="https://github.com/user-attachments/assets/53eab7e6-d9e7-4ba3-9083-ce3060325da1" />

---

## 🧪 How to Test

1. Go to a project's GLOFAS data source → open station details for any return period (e.g. 2 years).
2. Go back, open a different return period (5 years, 20 years) — verify title and table/chart data update (not cached from prior period).
3. Confirm the discharge forecast chart renders below the table using `dischargeSeries` from `ms.probFlood.getOneGlofas`.

---

## ⚠️ Notes for Reviewer

- `dischargeSeries` is a new field expected from `ms.probFlood.getOneGlofas` — backend must include it for the chart to render.