### PR TITLE
isAutomated and leadtime required

### DIFF
--- a/apps/rahat-ui/src/sections/projects/aa-2/activities/add/add.activity.view.tsx
+++ b/apps/rahat-ui/src/sections/projects/aa-2/activities/add/add.activity.view.tsx
@@ -145,7 +145,7 @@ export default function AddActivities() {
   const appTransports = useListAllTransports();
 
   const { FormSchema, form, communicationForm, defaultCommunicationValues } =
-    useActivityForm(phases, appTransports);
+    useActivityForm(appTransports);
 
   const handleFileChange = async (event: ChangeEvent<HTMLInputElement>) => {
     const files = event.target.files;
@@ -244,8 +244,11 @@ export default function AddActivities() {
   );
 
   useEffect(() => {
-    if (selectedPhase?.name === 'PREPAREDNESS') {
+    if (!selectedPhase?.isAutomatedActivity) {
       form.setValue('isAutomated', false);
+    }
+    if (!selectedPhase?.isRequiredLeadTime) {
+      form.setValue('leadTime', '');
     }
   }, [selectedPhase, form]);
 

--- a/apps/rahat-ui/src/sections/projects/aa-2/activities/edit/activity.edit.view.tsx
+++ b/apps/rahat-ui/src/sections/projects/aa-2/activities/edit/activity.edit.view.tsx
@@ -124,12 +124,11 @@ export default function EditActivity() {
 
   const redirectUpdatePath = redirectTo
     ? `/projects/aa/${projectID}/activities/${activityID}`
-    : `/projects/aa/${projectID}/activities/${activityID}${
-        backFrom ? `?from=${backFrom}` : ''
-      }`;
+    : `/projects/aa/${projectID}/activities/${activityID}${backFrom ? `?from=${backFrom}` : ''
+    }`;
 
   const { FormSchema, form, communicationForm, defaultCommunicationValues } =
-    useActivityForm(phases, appTransports);
+    useActivityForm(appTransports);
 
   // Handlers goes here
   const handleFileChange = async (event: ChangeEvent<HTMLInputElement>) => {
@@ -699,7 +698,7 @@ export default function EditActivity() {
                               className="bg-white shadow-sm rounded-xl p-4 border border-gray-200 flex items-center gap-3 hover:cursor-pointer hover:bg-gray-100"
                             >
                               {uploadFile.isPending &&
-                              uploadingFileName === file.fileName ? (
+                                uploadingFileName === file.fileName ? (
                                 <LoaderCircle className="text-green-600 animate-spin w-9 h-9" />
                               ) : (
                                 <FileCheck className="w-9 h-9 text-green-600" />

--- a/apps/rahat-ui/src/sections/projects/aa-2/activities/hooks/useActivityForm.ts
+++ b/apps/rahat-ui/src/sections/projects/aa-2/activities/hooks/useActivityForm.ts
@@ -1,24 +1,14 @@
 import { useMemo } from 'react';
 import { Transport } from '@rumsan/connect/src/types';
 import {
-  createActivityFormSchema,
+  activityFormSchema,
   createCommunicationFormSchema,
 } from '../schemas/activity.schemas';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
-export const useActivityForm = (
-  phases: Array<{
-    uuid: string;
-    name: string;
-    isRequiredLeadTime?: boolean;
-    isAutomatedActivity?: boolean;
-  }>,
-  appTransports?: Transport[],
-) => {
-  const FormSchema = useMemo(() => createActivityFormSchema(phases), [phases]);
-
+export const useActivityForm = (appTransports?: Transport[]) => {
   const CommunicationFormSchema = useMemo(
     () => createCommunicationFormSchema(appTransports),
     [appTransports],
@@ -45,8 +35,8 @@ export const useActivityForm = (
     defaultValues: defaultCommunicationValues,
   });
 
-  const form = useForm<z.infer<typeof FormSchema>>({
-    resolver: zodResolver(FormSchema),
+  const form = useForm<z.infer<typeof activityFormSchema>>({
+    resolver: zodResolver(activityFormSchema),
     mode: 'onChange',
     defaultValues: {
       title: '',
@@ -63,7 +53,7 @@ export const useActivityForm = (
   });
 
   return {
-    FormSchema,
+    FormSchema: activityFormSchema,
     CommunicationFormSchema,
     form,
     communicationForm,

--- a/apps/rahat-ui/src/sections/projects/aa-2/activities/schemas/activity.schemas.ts
+++ b/apps/rahat-ui/src/sections/projects/aa-2/activities/schemas/activity.schemas.ts
@@ -6,7 +6,7 @@ const activityDocumentSchema = z.object({
   fileName: z.string(),
 });
 
-const baseActivityFormSchema = z.object({
+export const activityFormSchema = z.object({
   title: z.string().min(2, { message: 'Title must be at least 4 character' }),
   responsibility: z.string().min(2, { message: 'Please enter responsibility' }),
   responsibleStation: z
@@ -26,47 +26,6 @@ const baseActivityFormSchema = z.object({
   activityDocuments: z.array(activityDocumentSchema).optional(),
 });
 
-export const createActivityFormSchema = (
-  phases: Array<{
-    uuid: string;
-    name: string;
-    isRequiredLeadTime?: boolean;
-    isAutomatedActivity?: boolean;
-  }>,
-) => {
-  return baseActivityFormSchema.superRefine((data, ctx) => {
-    const selectedPhase = phases.find((p) => p.uuid === data.phaseId);
-    if (!selectedPhase) return;
-
-    if (selectedPhase.isRequiredLeadTime) {
-      if (!data.leadTime) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: 'Lead time is required for this phase',
-          path: ['leadTime'],
-        });
-      } else {
-        const parts = data.leadTime.split(' ');
-        const valuePart = parts[0]?.trim();
-        if (!valuePart) {
-          ctx.addIssue({
-            code: z.ZodIssueCode.custom,
-            message: 'Lead time is required for this phase',
-            path: ['leadTime'],
-          });
-        }
-      }
-    }
-
-    if (selectedPhase.isAutomatedActivity && !data.isAutomated) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: 'This field is required',
-        path: ['isAutomated'],
-      });
-    }
-  });
-};
 
 const baseCommunicationFormSchema = z.object({
   communicationTitle: z


### PR DESCRIPTION
## 🔗 Related Issue

<!-- Link issue (if any) -->
- https://github.com/rahataid/rahat-ui/issues/2309
- [x] Added issue link

## 📌 Description

<!-- What does this PR do? Explain clearly -->

- While adding an activity, if the selected phase has Automated Activity = true and Lead Time = true in its configuration, the Automated Activity and Lead Time fields are displayed in the form. However, these fields remain optional and do not have any mandatory validation.
- [Demo](https://www.awesomescreenshot.com/video/53917674?key=41317e96916fb7c118b7d594a54a3dbf)



---

## ✅ Checklist

- [x] No `console.log` or debug code left
- [ ] Proper error handling implemented
- [ ] Loading states handled (if needed)
- [x] API calls handled safely
- [x] No unnecessary code or comments
- [x] Self-reviewed code for logic, edge cases, and potential issues

---

## 🎯 Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] UI update
- [ ] Refactor
- [ ] Performance improvement

---

## 📸 Before / After

### Before

## <!-- Add screenshots -->
<img width="1470" height="832" alt="isAutomated_before" src="https://github.com/user-attachments/assets/5d4610f6-2a6c-47b1-aaab-a65004082b2b" />

### After

## <!-- Add screenshots -->

---
<img width="1468" height="830" alt="Screenshot 2026-06-24 at 3 13 49 PM" src="https://github.com/user-attachments/assets/837bf914-2a4d-41df-9f80-2958c7486198" />


## 🧪 How to Test

<!-- Steps to test this PR -->

1. Go to Add Activity Page and try creating an activity with selecting the phase which has `isAutomatedActivity` and `requiredLeadtime` 
2. And leave the Is Automated Activity and Leadtime empty
3. Submit the form

---

## ⚠️ Notes for Reviewer

<!-- Anything special reviewer should know -->

- Check properly with opening network tab
