### PR TITLE
bug fix: tarnucate the long communcation title

### DIFF
--- a/apps/rahat-ui/src/sections/projects/aa-2/activities/components/communicationCard.tsx
+++ b/apps/rahat-ui/src/sections/projects/aa-2/activities/components/communicationCard.tsx
@@ -138,7 +138,7 @@ export function CommunicationCard({
           </div>
 
           <div className="flex-1 min-w-0">
-            {/* Title Row */}
+            {/* Title */}
             <div className="flex items-center gap-2 mb-1">
               <TooltipWrapper
                 tip={`Communication Title: ${activityCommunication?.communicationTitle}`}

--- a/apps/rahat-ui/src/sections/projects/aa-2/activities/components/communicationCard.tsx
+++ b/apps/rahat-ui/src/sections/projects/aa-2/activities/components/communicationCard.tsx
@@ -143,7 +143,7 @@ export function CommunicationCard({
               <TooltipWrapper
                 tip={`Communication Title: ${activityCommunication?.communicationTitle}`}
               >
-                <h3 className="font-medium text-gray-900 truncate">
+                <h3 className="font-medium text-gray-900 truncate w-[360px]">
                   {activityCommunication?.communicationTitle}
                 </h3>
               </TooltipWrapper>


### PR DESCRIPTION
## 🔗 Related Issue

https://github.com/rahataid/rahat-ui/issues/2327
- [x] Added issue link

## 📌 Description


- Truncated long communication titles with an ellipsis (...) to prevent UI layout issues.
- Preserved the existing layout and improved readability for long communication titles.
---

## ✅ Checklist

- [x] No `console.log` or debug code left
- [ ] Proper error handling implemented
- [ ] Loading states handled (if needed)
- [ ] API calls handled safely
- [x] No unnecessary code or comments
- [x] Self-reviewed code for logic, edge cases, and potential issues

---

## 🎯 Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] UI update
- [ ] Refactor
- [ ] Performance improvement

---

## 📸 Before / After

### Before

<img width="1008" height="690" alt="image" src="https://github.com/user-attachments/assets/8fe13b5c-e8fe-40cf-8106-98906551e8b4" />

### After

<img width="1453" height="929" alt="image" src="https://github.com/user-attachments/assets/0512a7b3-8afa-41f4-91ef-4406986c7a22" />

---

## 🧪 How to Test

1. Go to the **Activity** page.
2. Open an activity that contains a communication with a long title.
4. Verify that long communication titles are truncated with an ellipsis (`...`).
5. Hover over the truncated title and confirm that the tooltip displays the full communication title.
6. Verify that short communication titles are displayed without truncation.

---

## ⚠️ Notes for Reviewer

- Truncation is applied only when the title exceeds the available display area.
- The full communication title remains accessible via the tooltip.
