### PR TITLE
[ENHANCEMENT] Serialize blockchain error for action reverted for lay clients

### DIFF
--- a/apps/rahat-ui/src/sections/projects/aa-2/fundManagement/columns/useFMColumns.tsx
+++ b/apps/rahat-ui/src/sections/projects/aa-2/fundManagement/columns/useFMColumns.tsx
@@ -1,15 +1,19 @@
 import React from 'react';
 import { ColumnDef } from '@tanstack/react-table';
-import { Eye, TriangleAlert } from 'lucide-react';
+import { ChevronDown, Eye, TriangleAlert } from 'lucide-react';
 import TooltipComponent from 'apps/rahat-ui/src/components/tooltip';
 import { useParams, useRouter } from 'next/navigation';
 import { Badge } from '@rahat-ui/shadcn/src/components/ui/badge';
 import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from '@rahat-ui/shadcn/src/components/ui/tooltip';
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@rahat-ui/shadcn/src/components/ui/popover';
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@rahat-ui/shadcn/src/components/ui/collapsible';
 import { TruncatedCell } from 'apps/rahat-ui/src/sections/projects/aa-2/stakeholders/component/TruncatedCell';
 
 export enum FundStatus {
@@ -115,24 +119,33 @@ export const useFundManagementTableColumns = () => {
               handleOnClick={() => handleViewClick(row.original.uuid)}
             />
             {(status === FundStatus.FAILED || status === FundStatus.ERROR) && (
-              <TooltipProvider delayDuration={200}>
-                <Tooltip>
-                  <TooltipTrigger>
+              <Popover>
+                <PopoverTrigger asChild>
+                  <button type="button" aria-label="View failure details">
                     <TriangleAlert size={16} strokeWidth={1.5} color="red" />
-                  </TooltipTrigger>
-                  <TooltipContent side="left" className="rounded-sm w-64">
-                    <div className="flex space-x-2 items-center">
-                      <TriangleAlert size={16} strokeWidth={1.5} color="red" />
-                      <span className="font-semibold text-sm/6">
-                        Transaction Failed
-                      </span>
-                    </div>
-                    <p className="text-gray-500 text-sm mt-1">
-                      {row.original?.info?.error ?? 'Something went wrong!!'}
-                    </p>
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
+                  </button>
+                </PopoverTrigger>
+                <PopoverContent side="left" className="rounded-sm w-72">
+                  <div className="flex space-x-2 items-center">
+                    <TriangleAlert size={16} strokeWidth={1.5} color="red" />
+                    <span className="font-semibold text-sm/6">
+                      Token disbursement failed for this group. Contact
+                      admin for assistance.
+                    </span>
+                  </div>
+                  <Collapsible className="mt-2">
+                    <CollapsibleTrigger className="flex items-center gap-1 text-xs text-muted-foreground hover:text-primary">
+                      <ChevronDown size={12} />
+                      View technical details
+                    </CollapsibleTrigger>
+                    <CollapsibleContent>
+                      <p className="text-gray-500 text-xs mt-2 break-words">
+                        {row.original?.info?.error ?? 'Something went wrong!!'}
+                      </p>
+                    </CollapsibleContent>
+                  </Collapsible>
+                </PopoverContent>
+              </Popover>
             )}
           </div>
         );

--- a/apps/rahat-ui/src/sections/projects/aa-2/fundManagement/columns/useFMColumns.tsx
+++ b/apps/rahat-ui/src/sections/projects/aa-2/fundManagement/columns/useFMColumns.tsx
@@ -5,10 +5,10 @@ import TooltipComponent from 'apps/rahat-ui/src/components/tooltip';
 import { useParams, useRouter } from 'next/navigation';
 import { Badge } from '@rahat-ui/shadcn/src/components/ui/badge';
 import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from '@rahat-ui/shadcn/src/components/ui/popover';
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from '@rahat-ui/shadcn/src/components/ui/hover-card';
 import {
   Collapsible,
   CollapsibleContent,
@@ -119,13 +119,13 @@ export const useFundManagementTableColumns = () => {
               handleOnClick={() => handleViewClick(row.original.uuid)}
             />
             {(status === FundStatus.FAILED || status === FundStatus.ERROR) && (
-              <Popover>
-                <PopoverTrigger asChild>
+              <HoverCard openDelay={100}>
+                <HoverCardTrigger asChild>
                   <button type="button" aria-label="View failure details">
                     <TriangleAlert size={16} strokeWidth={1.5} color="red" />
                   </button>
-                </PopoverTrigger>
-                <PopoverContent side="left" className="rounded-sm w-72">
+                </HoverCardTrigger>
+                <HoverCardContent side="left" className="rounded-sm w-72">
                   <div className="flex space-x-2 items-center">
                     <TriangleAlert size={16} strokeWidth={1.5} color="red" />
                     <span className="font-semibold text-sm/6">
@@ -144,8 +144,8 @@ export const useFundManagementTableColumns = () => {
                       </p>
                     </CollapsibleContent>
                   </Collapsible>
-                </PopoverContent>
-              </Popover>
+                </HoverCardContent>
+              </HoverCard>
             )}
           </div>
         );


### PR DESCRIPTION
## 🔗 Related Issue
Linked Issue: https://github.com/orgs/rahataid/projects/61/views/14?sliceBy%5Bvalue%5D=mohit-rumsan&filterQuery=projects%3AAA%2CCore%2CCT%2C+assignee%3Amohit-rumsan&pane=issue&itemId=187985509&issue=rahataid%7Crahat-ui%7C2139

## 📌 Description

Fund management's "Transaction Failed" indicator showed the raw blockchain `info.error` string directly, which is unreadable for non-technical admins. This PR replaces the tooltip with a hover card: a friendly message ("Token disbursement failed for this group. Contact admin for assistance.") is shown by default, with the raw error tucked behind a "View technical details" collapsible toggle for anyone who needs it.

---

## ✅ Checklist

- [x] No `console.log` or debug code left
- [x] Proper error handling implemented
- [x] Loading states handled (if needed)
- [x] API calls handled safely
- [x] No unnecessary code or comments
- [x] Self-reviewed code for logic, edge cases, and potential issues

---

## 🎯 Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] UI update
- [ ] Refactor
- [ ] Performance improvement

---

## 📸 Before / After

### Before
<img width="266" height="219" alt="image" src="https://github.com/user-attachments/assets/5ca9ae48-a9fe-4572-b618-fefa3349d5a9" />


### After
<img width="704" height="288" alt="image" src="https://github.com/user-attachments/assets/2eec886d-6c13-479c-b39e-10575c09a665" />
<img width="745" height="680" alt="image" src="https://github.com/user-attachments/assets/84e7205e-075d-41f0-a5fe-09f2577c88a1" />


---

## 🧪 How to Test

1. Go to a project's Fund Management list and locate a fund row with status `FAILED` or `ERROR`.
2. Hover over the red warning icon in the Actions column.
3. Confirm the friendly message appears immediately on hover; click "View technical details" to confirm the raw error text still shows underneath.

---

## ⚠️ Notes for Reviewer

- Swapped `Tooltip` for `HoverCard` (Radix) so the friendly message appears without requiring a click; the raw error remains gated behind an explicit "View technical details" expand for technical users.
- No backend changes — this is a presentation-only fix.

