### PR TITLE
2353 integrate project close feature in the UI

### DIFF
--- a/apps/rahat-ui/src/app/project-info/layout.tsx
+++ b/apps/rahat-ui/src/app/project-info/layout.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import * as React from 'react';
+
+import DashboardLayout from '../dashboard/layout';
+import SettingFieldDefinitionLayout from '../../sections/settings/settingsFieldDefinitionLayout';
+import { useSettingFieldDefinitionNavItems } from '../../sections/settings/useNavItems';
+import { useSecondPanel } from '../../providers/second-panel-provider';
+
+export default function SettingsLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const { secondPanel } = useSecondPanel();
+
+  const menuItems = useSettingFieldDefinitionNavItems();
+
+  return (
+    <DashboardLayout>
+      <SettingFieldDefinitionLayout menuItems={menuItems}>
+        {secondPanel ? [children, secondPanel] : children}
+      </SettingFieldDefinitionLayout>
+    </DashboardLayout>
+  );
+}

--- a/apps/rahat-ui/src/app/project-info/page.tsx
+++ b/apps/rahat-ui/src/app/project-info/page.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import ListProject from "../../sections/projects/projectList";
+
+export default function ProjectInfoPage() {
+  return <ListProject />;
+}

--- a/apps/rahat-ui/src/sections/projects/components/project-header.tsx
+++ b/apps/rahat-ui/src/sections/projects/components/project-header.tsx
@@ -67,7 +67,7 @@ export function ProjectNav({
   };
 
   return (
-    <div className="sticky top-0 z-1 h-14 w-full flex items-center pl-4 pr-6 py-2 bg-card border-b">
+    <div className="sticky top-0 z-10 h-14 w-full flex items-center pl-4 pr-6 py-2 bg-card border-b">
       <div className="flex items-center space-x-4">{component}</div>
       <div className="fixed top-2 right-6 z-50 flex gap-4 items-center">
         <ConnectWallet />

--- a/apps/rahat-ui/src/sections/projects/components/project-header.tsx
+++ b/apps/rahat-ui/src/sections/projects/components/project-header.tsx
@@ -26,17 +26,11 @@ import { NotificationButton } from 'apps/rahat-ui/src/components/notification-bu
 import ConnectWallet from 'apps/rahat-ui/src/components/wallet/connect-wallet';
 
 export function ProjectNav({
-  //   data = [],
-  //   subData = [],
   component,
+  isClosed = false,
 }: {
-  //   data?: {
-  //     title: string;
-  //     path: string;
-  //     children?: { title: string; path: string }[];
-  //   }[];
-  //   subData?: { title: string; path: string }[];
   component?: React.ReactNode;
+  isClosed?: boolean;
 }) {
   const currentPath = usePathname();
   const params = useParams();
@@ -70,7 +64,7 @@ export function ProjectNav({
     <div className="sticky top-0 z-10 h-14 w-full flex items-center pl-4 pr-6 py-2 bg-card border-b">
       <div className="flex items-center space-x-4">{component}</div>
       <div className="fixed top-2 right-6 z-50 flex gap-4 items-center">
-        <ConnectWallet />
+        {!isClosed && <ConnectWallet />}
         {showNotification && <NotificationButton unreadCount={0} />}
         <DropdownMenu>
           <DropdownMenuTrigger>

--- a/apps/rahat-ui/src/sections/projects/components/project.layout.tsx
+++ b/apps/rahat-ui/src/sections/projects/components/project.layout.tsx
@@ -96,10 +96,10 @@ const ProjectLayout: FC<ProjectLayoutProps> = ({
         <div className="w-full min-w-0">
           <ProjectNav component={headerNav} />
           {isClosed && (
-            <Alert className="sticky top-14 z-10 rounded-none border-x-0 border-t-0 bg-red-50 border-red-300 text-red-800 py-2 px-4">
-              <ShieldAlert className="h-4 w-4 !text-red-600" />
-              <AlertTitle className="text-red-700">Project Closed</AlertTitle>
-              <AlertDescription className="text-red-600">
+            <Alert className="sticky top-14 z-10 rounded-none border-x-0 border-t-0 bg-red-50 border-red-300 text-red-800 py-3 px-4">
+              <ShieldAlert className="h-6 w-6 !text-red-600" />
+              <AlertTitle className="text-red-700 text-base">Project Closed</AlertTitle>
+              <AlertDescription className="text-red-600 text-sm">
                 This project has been closed. You can view the data but cannot perform any create, update, or delete operations.
               </AlertDescription>
             </Alert>

--- a/apps/rahat-ui/src/sections/projects/components/project.layout.tsx
+++ b/apps/rahat-ui/src/sections/projects/components/project.layout.tsx
@@ -45,11 +45,11 @@ const ProjectLayout: FC<ProjectLayoutProps> = ({
         <div className="w-full min-w-0">
           <ProjectNav component={headerNav} isClosed={isClosed} />
           {isClosed && (
-            <Alert className="sticky top-14 z-10 rounded-none border-x-0 border-t-0 bg-red-50 border-red-300 text-red-800 py-3 px-4">
-              <ShieldAlert className="h-6 w-6 !text-red-600" />
-              <AlertTitle className="text-red-700 text-base">Project Closed</AlertTitle>
-              <AlertDescription className="text-red-600 text-sm">
-                This project has been closed and is now in read-only mode. You can view the project data, but you cannot create, update, or delete any records              </AlertDescription>
+            <Alert className="sticky top-14 z-10 rounded-none border-x-0 border-t-0 bg-red-50 border-red-300 text-red-800 py-1 px-2 md:py-3 md:px-4">
+              <ShieldAlert className="h-3 w-3 md:h-6 md:w-6 !text-red-600" />
+              <AlertTitle className="text-red-700 text-[10px] md:text-sm">Project Closed</AlertTitle>
+              <AlertDescription className="text-red-600 text-[10px] md:text-sm">
+                This project has been closed. You can only view the project data.</AlertDescription>
             </Alert>
           )}
           <div className="min-w-0">{children}</div>

--- a/apps/rahat-ui/src/sections/projects/components/project.layout.tsx
+++ b/apps/rahat-ui/src/sections/projects/components/project.layout.tsx
@@ -13,6 +13,13 @@ import { useProjectHeaderItems } from './useProjectHeaderItems';
 import { useProjectNavItems } from './useProjectNavItems';
 import { SidebarProvider } from '@rahat-ui/shadcn/src/components/ui/sidebar';
 import { ProjectSidebar } from 'apps/rahat-ui/src/sidebar-components/project-sidebar';
+import { useProjectStore } from '@rahat-ui/query';
+import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
+} from '@rahat-ui/shadcn/src/components/ui/alert';
+import { ShieldAlert } from 'lucide-react';
 
 type ProjectLayoutProps = {
   children: React.ReactNode | React.ReactNode[];
@@ -26,8 +33,9 @@ const ProjectLayout: FC<ProjectLayoutProps> = ({
   navFooter,
 }) => {
   const { navItems: menuItems } = useProjectNavItems(projectType);
-
   const { headerNav } = useProjectHeaderItems(projectType);
+  const singleProject = useProjectStore((s) => s.singleProject);
+  const isClosed = singleProject?.status === 'CLOSED';
 
   // --- Previous Project Layout---
   // const renderResizablePanel = (children: React.ReactNode, index?: number) => {
@@ -87,6 +95,15 @@ const ProjectLayout: FC<ProjectLayoutProps> = ({
         ))}
         <div className="w-full min-w-0">
           <ProjectNav component={headerNav} />
+          {isClosed && (
+            <Alert className="sticky top-14 z-10 rounded-none border-x-0 border-t-0 bg-red-50 border-red-300 text-red-800 py-2 px-4">
+              <ShieldAlert className="h-4 w-4 !text-red-600" />
+              <AlertTitle className="text-red-700">Project Closed</AlertTitle>
+              <AlertDescription className="text-red-600">
+                This project has been closed. You can view the data but cannot perform any create, update, or delete operations.
+              </AlertDescription>
+            </Alert>
+          )}
           <div className="min-w-0">{children}</div>
         </div>
       </SidebarProvider>

--- a/apps/rahat-ui/src/sections/projects/components/project.layout.tsx
+++ b/apps/rahat-ui/src/sections/projects/components/project.layout.tsx
@@ -1,14 +1,8 @@
 'use client';
 
-import {
-  ResizableHandle,
-  ResizablePanel,
-  ResizablePanelGroup,
-} from '@rahat-ui/shadcn/src/components/ui/resizable';
 import { FC } from 'react';
 import { ProjectType } from './nav-items.types';
 import { ProjectNav } from './project-header';
-import ProjectNavView from './project.nav.view';
 import { useProjectHeaderItems } from './useProjectHeaderItems';
 import { useProjectNavItems } from './useProjectNavItems';
 import { SidebarProvider } from '@rahat-ui/shadcn/src/components/ui/sidebar';
@@ -37,53 +31,8 @@ const ProjectLayout: FC<ProjectLayoutProps> = ({
   const singleProject = useProjectStore((s) => s.singleProject);
   const isClosed = singleProject?.status === 'CLOSED';
 
-  // --- Previous Project Layout---
-  // const renderResizablePanel = (children: React.ReactNode, index?: number) => {
-  //   return (
-  //     <ResizablePanel minSize={40} key={index}>
-  //       {children}
-  //       {/* <ScrollArea className="h-[calc(100vh-66px)]">{children}</ScrollArea> */}
-  //     </ResizablePanel>
-  //   );
-  // };
-  // const renderChildren = () => {
-  //   if (Array.isArray(children)) {
-  //     return children.map((child, index) => {
-  //       return (
-  //         <>
-  //           <ResizableHandle withHandle />
-  //           {renderResizablePanel(child, index)}
-  //         </>
-  //       );
-  //     });
-  //   }
-  //   return (
-  //     <>
-  //       {/* <ResizableHandle /> */}
-  //       {renderResizablePanel(children)}
-  //     </>
-  //   );
-  // };
-
   return (
     <>
-      {/* 
-      <ProjectNav component={headerNav} />
-      <ResizablePanelGroup direction="horizontal">
-        <ResizablePanel defaultSize={15} minSize={15} maxSize={15}>
-          {menuItems.map((item) => (
-            <ProjectNavView
-              key={item.title}
-              title={item.title}
-              items={item.children}
-            />
-          ))}
-          {navFooter}
-        </ResizablePanel>
-        {renderChildren()}
-      </ResizablePanelGroup> 
-      */}
-
       <SidebarProvider>
         {menuItems.map((item) => (
           <ProjectSidebar
@@ -94,14 +43,13 @@ const ProjectLayout: FC<ProjectLayoutProps> = ({
           />
         ))}
         <div className="w-full min-w-0">
-          <ProjectNav component={headerNav} />
+          <ProjectNav component={headerNav} isClosed={isClosed} />
           {isClosed && (
             <Alert className="sticky top-14 z-10 rounded-none border-x-0 border-t-0 bg-red-50 border-red-300 text-red-800 py-3 px-4">
               <ShieldAlert className="h-6 w-6 !text-red-600" />
               <AlertTitle className="text-red-700 text-base">Project Closed</AlertTitle>
               <AlertDescription className="text-red-600 text-sm">
-                This project has been closed. You can view the data but cannot perform any create, update, or delete operations.
-              </AlertDescription>
+                This project has been closed and is now in read-only mode. You can view the project data, but you cannot create, update, or delete any records              </AlertDescription>
             </Alert>
           )}
           <div className="min-w-0">{children}</div>

--- a/apps/rahat-ui/src/sections/projects/projectCard.tsx
+++ b/apps/rahat-ui/src/sections/projects/projectCard.tsx
@@ -7,6 +7,7 @@ import { Button } from '@rahat-ui/shadcn/src/components/ui/button';
 import { UUID } from 'crypto';
 import { TruncatedCell } from './aa-2/stakeholders/component/TruncatedCell';
 import { StatusBadge } from './projectList';
+import { toast } from 'react-toastify';
 
 
 
@@ -37,14 +38,20 @@ export default function CommonCard({
 }: CardProps) {
   const router = useRouter();
 
+  const isNotReady = status === 'NOT_READY';
+
   const handleClick = () => {
+    if (isNotReady) {
+      toast.warn('This project is not ready yet. You cannot enter into it.');
+      return;
+    }
     router.push(`/projects/${badge.toLowerCase()}/${address}`);
   };
 
   return (
     <Card
       onClick={handleClick}
-      className={`cursor-pointer rounded-md border shadow`}
+      className="rounded-md border shadow  cursor-pointer"
     >
       <div className="p-4">
         <div className="rounded-md bg-secondary flex justify-center">

--- a/apps/rahat-ui/src/sections/projects/projectCard.tsx
+++ b/apps/rahat-ui/src/sections/projects/projectCard.tsx
@@ -6,6 +6,11 @@ import { Badge } from '@rahat-ui/shadcn/src/components/ui/badge';
 import { Button } from '@rahat-ui/shadcn/src/components/ui/button';
 import { UUID } from 'crypto';
 import { TruncatedCell } from './aa-2/stakeholders/component/TruncatedCell';
+import { StatusBadge } from './projectList';
+
+
+
+
 
 type CardProps = {
   address: UUID;
@@ -86,12 +91,15 @@ export default function CommonCard({
             </Button>
           )}
         </div>
-        <Badge
-          variant="outline"
-          className="border-primary text-primary cursor-auto bg-secondary mb-2"
-        >
-          {badge}
-        </Badge>
+        <div className="flex items-center gap-2 mb-2">
+          <Badge
+            variant="outline"
+            className="border-primary text-primary cursor-auto bg-secondary"
+          >
+            {badge}
+          </Badge>
+          <StatusBadge status={status} />
+        </div>
         <div>
           <TruncatedCell
             text={subTitle}

--- a/apps/rahat-ui/src/sections/projects/projectList.tsx
+++ b/apps/rahat-ui/src/sections/projects/projectList.tsx
@@ -1,0 +1,151 @@
+'use client';
+
+import { useProjectClose, useProjectEdit, useProjectList } from '@rahat-ui/query';
+import { Badge } from '@rahat-ui/shadcn/src/components/ui/badge';
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@rahat-ui/shadcn/src/components/ui/alert-dialog';
+import { Project } from '@rahataid/sdk/project/project.types';
+import { UUID } from 'crypto';
+import { ColumnDef, getCoreRowModel, useReactTable } from '@tanstack/react-table';
+import { DemoTable } from '../../common';
+import { CircleX } from 'lucide-react';
+import TooltipComponent from 'apps/rahat-ui/src/components/tooltip';
+
+
+const STATUS_CONFIG: Record<string, { label: string; className: string }> = {
+  NOT_READY: { label: 'Not Ready', className: 'bg-yellow-100 text-yellow-700 border-yellow-300' },
+  ACTIVE: { label: 'Active', className: 'bg-green-100 text-green-700 border-green-300' },
+  CLOSED: { label: 'Closed', className: 'bg-red-100 text-red-700 border-red-300' },
+};
+
+function StatusBadge({ status }: { status?: string }) {
+  const config = STATUS_CONFIG[status ?? ''];
+  return (
+    <Badge className={`border ${config?.className ?? 'bg-gray-100 text-gray-500 border-gray-300'}`}>
+      {config?.label ?? status ?? '—'}
+    </Badge>
+  );
+}
+
+export default function ListProject() {
+  const { data, isLoading } = useProjectList();
+  const editProject = useProjectEdit();
+  const closeProject = useProjectClose();
+  const projects: Project[] = data?.data ?? [];
+
+  const handleCloseProject = (uuid?: UUID) => {
+    if (!uuid) return;
+    closeProject.mutate({ uuid, data: { status: 'CLOSED' } });
+  };
+  const columns: ColumnDef<any>[] = [
+    {
+      header: 'Name',
+      accessorKey: 'name',
+      cell: ({ row }) => <div>{row.getValue('name')}</div>,
+    },
+    {
+      header: 'Description',
+      accessorKey: 'description',
+      cell: ({ row }) => <div>{row.getValue('description')}</div>,
+    },
+    {
+      header: 'Type',
+      accessorKey: 'type',
+      cell: ({ row }) => <div>{row.original.type?.toUpperCase()}</div>,
+    },
+    {
+      header: 'Status',
+      accessorKey: 'status',
+      cell: ({ row }) => <StatusBadge status={row.original.status} />,
+    },
+    {
+      header: 'Created At',
+      accessorKey: 'createdAt',
+      cell: ({ row }) => {
+        return (
+          <div>
+            {row.original.createdAt
+              ? new Date(row.original.createdAt).toLocaleDateString()
+              : '—'}
+          </div>
+        );
+      },
+    },
+    {
+      id: 'actions',
+      header: 'Actions',
+      cell: ({ row }) => {
+        const project = row.original;
+        return (
+
+          <AlertDialog>
+            <AlertDialogTrigger asChild>
+              <button
+                disabled={project.status === 'CLOSED'}
+                className="disabled:opacity-40 disabled:cursor-not-allowed"
+              >
+                <TooltipComponent
+                  Icon={CircleX}
+                  tip="Close Project"
+                  iconStyle="text-red-500 hover:text-red-700 cursor-pointer"
+                  handleOnClick={() => { }
+                  }
+
+                />
+                {/* <CircleX size={16} strokeWidth={1.8} className="text-red-500 hover:text-red-700" /> */}
+              </button>
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Close &quot;{project.name}&quot;?</AlertDialogTitle>
+                <AlertDialogDescription>
+                  Are you sure you want to close this project? Once a project is
+                  closed, it cannot be reactivated.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>Cancel</AlertDialogCancel>
+                <AlertDialogAction
+                  className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                  onClick={() => handleCloseProject(project.uuid as UUID)}
+                >
+                  {/* Confirm */}
+                  {closeProject.isPending ? 'Closing...' : 'Confirm'}
+
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        );
+      },
+    },
+  ];
+  const table = useReactTable({
+    manualPagination: true,
+    data: projects || [],
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+  });
+
+  return (
+    <div className="p-6">
+      <h2 className="text-xl font-semibold mb-4">Projects</h2>
+      <DemoTable
+        table={table}
+        tableHeight={'h-[calc(100vh-320px)]'}
+        loading={isLoading}
+        message="No Projects Found"
+      />
+    </div>
+  );
+}

--- a/apps/rahat-ui/src/sections/projects/projectList.tsx
+++ b/apps/rahat-ui/src/sections/projects/projectList.tsx
@@ -24,18 +24,18 @@ import {
 } from '@tanstack/react-table';
 import { DemoTable, SearchInput } from '../../common';
 import { CircleX } from 'lucide-react';
-import TooltipComponent from 'apps/rahat-ui/src/components/tooltip';
 import { useState } from 'react';
 import SelectComponent from './comms/select.component';
 import CustomPagination from '../../components/customPagination';
+import TooltipWrapper from '../../components/tooltip.wrapper';
 
-const STATUS_CONFIG: Record<string, { label: string; className: string }> = {
+export const STATUS_CONFIG: Record<string, { label: string; className: string }> = {
   NOT_READY: { label: 'Not Ready', className: 'bg-yellow-100 text-yellow-700 border-yellow-300' },
   ACTIVE: { label: 'Active', className: 'bg-green-100 text-green-700 border-green-300' },
   CLOSED: { label: 'Closed', className: 'bg-red-100 text-red-700 border-red-300' },
 };
 
-function StatusBadge({ status }: { status?: string }) {
+export function StatusBadge({ status }: { status?: string }) {
   const config = STATUS_CONFIG[status ?? ''];
   return (
     <Badge className={`border ${config?.className ?? 'bg-gray-100 text-gray-500 border-gray-300'}`}>
@@ -71,7 +71,7 @@ export default function ListProject() {
     });
   };
 
-  const columns: ColumnDef<any>[] = [
+  const columns: ColumnDef<Project>[] = [
     {
       header: 'Name',
       accessorKey: 'name',
@@ -107,14 +107,19 @@ export default function ListProject() {
       header: 'Actions',
       cell: ({ row }) => {
         const project = row.original;
+        console.log('project in actions', project);
         return (
-          <TooltipComponent
-            Icon={CircleX}
-            tip="Close Project"
-            iconStyle="text-red-500 hover:text-red-700 cursor-pointer"
-            disable={project.status === 'CLOSED'}
-            handleOnClick={() => setSelectedProject(project)}
-          />
+
+          <TooltipWrapper tip={project.status === 'CLOSED' ? 'Project is Closed' : 'Close Project'} >
+
+            <button
+              onClick={() => setSelectedProject(project)}
+              className="text-red-500 hover:text-red-700 cursor-pointer disabled:cursor-not-allowed disabled:text-gray-400"
+              disabled={project.status === 'CLOSED'}
+            >
+              <CircleX />
+            </button>
+          </TooltipWrapper>
         );
       },
     },

--- a/apps/rahat-ui/src/sections/projects/projectList.tsx
+++ b/apps/rahat-ui/src/sections/projects/projectList.tsx
@@ -23,7 +23,7 @@ import {
   useReactTable,
 } from '@tanstack/react-table';
 import { DemoTable, SearchInput } from '../../common';
-import { CircleX } from 'lucide-react';
+import { LockKeyhole, LockKeyholeOpen } from 'lucide-react';
 import { useState } from 'react';
 import SelectComponent from './comms/select.component';
 import CustomPagination from '../../components/customPagination';
@@ -118,10 +118,13 @@ export default function ListProject() {
 
             <button
               onClick={() => setSelectedProject(project)}
-              className="text-red-500 hover:text-red-700 cursor-pointer disabled:cursor-not-allowed disabled:text-gray-400"
+              className=" cursor-pointer disabled:cursor-not-allowed disabled:text-gray-400"
               disabled={project.status === 'CLOSED'}
             >
-              <CircleX />
+
+              {
+                project.status === 'CLOSED' ? <LockKeyhole /> :
+                  <LockKeyholeOpen />}
             </button>
           </TooltipWrapper>
         );

--- a/apps/rahat-ui/src/sections/projects/projectList.tsx
+++ b/apps/rahat-ui/src/sections/projects/projectList.tsx
@@ -1,8 +1,7 @@
 'use client';
 
-import { useProjectClose, useProjectEdit, useProjectList } from '@rahat-ui/query';
+import { useProjectClose, useProjectList } from '@rahat-ui/query';
 import { Badge } from '@rahat-ui/shadcn/src/components/ui/badge';
-
 import {
   AlertDialog,
   AlertDialogAction,
@@ -12,15 +11,23 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
-  AlertDialogTrigger,
 } from '@rahat-ui/shadcn/src/components/ui/alert-dialog';
 import { Project } from '@rahataid/sdk/project/project.types';
 import { UUID } from 'crypto';
-import { ColumnDef, getCoreRowModel, useReactTable } from '@tanstack/react-table';
-import { DemoTable } from '../../common';
+import {
+  ColumnDef,
+  ColumnFiltersState,
+  getCoreRowModel,
+  getFilteredRowModel,
+  getPaginationRowModel,
+  useReactTable,
+} from '@tanstack/react-table';
+import { DemoTable, SearchInput } from '../../common';
 import { CircleX } from 'lucide-react';
 import TooltipComponent from 'apps/rahat-ui/src/components/tooltip';
-
+import { useState } from 'react';
+import SelectComponent from './comms/select.component';
+import CustomPagination from '../../components/customPagination';
 
 const STATUS_CONFIG: Record<string, { label: string; className: string }> = {
   NOT_READY: { label: 'Not Ready', className: 'bg-yellow-100 text-yellow-700 border-yellow-300' },
@@ -39,19 +46,37 @@ function StatusBadge({ status }: { status?: string }) {
 
 export default function ListProject() {
   const { data, isLoading } = useProjectList();
-  const editProject = useProjectEdit();
   const closeProject = useProjectClose();
+
   const projects: Project[] = data?.data ?? [];
 
-  const handleCloseProject = (uuid?: UUID) => {
-    if (!uuid) return;
-    closeProject.mutate({ uuid, data: { status: 'CLOSED' } });
+  const [selectedProject, setSelectedProject] = useState<Project | null>(null);
+  const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
+
+  const handleCloseProject = () => {
+    if (!selectedProject?.uuid) return;
+    closeProject.mutate(
+      { uuid: selectedProject.uuid as UUID, data: { status: 'CLOSED' } },
+      { onSuccess: () => setSelectedProject(null) },
+    );
   };
+
+  const getFilterValue = (id: string) =>
+    columnFilters.find((f) => f.id === id)?.value as string | undefined;
+
+  const setFilter = (id: string, value: string) => {
+    setColumnFilters((prev) => {
+      const rest = prev.filter((f) => f.id !== id);
+      return value ? [...rest, { id, value }] : rest;
+    });
+  };
+
   const columns: ColumnDef<any>[] = [
     {
       header: 'Name',
       accessorKey: 'name',
       cell: ({ row }) => <div>{row.getValue('name')}</div>,
+      filterFn: 'includesString',
     },
     {
       header: 'Description',
@@ -67,19 +92,15 @@ export default function ListProject() {
       header: 'Status',
       accessorKey: 'status',
       cell: ({ row }) => <StatusBadge status={row.original.status} />,
+      filterFn: 'equalsString',
     },
     {
       header: 'Created At',
       accessorKey: 'createdAt',
-      cell: ({ row }) => {
-        return (
-          <div>
-            {row.original.createdAt
-              ? new Date(row.original.createdAt).toLocaleDateString()
-              : '—'}
-          </div>
-        );
-      },
+      cell: ({ row }) =>
+        row.original.createdAt
+          ? new Date(row.original.createdAt).toLocaleDateString()
+          : '—',
     },
     {
       id: 'actions',
@@ -87,65 +108,91 @@ export default function ListProject() {
       cell: ({ row }) => {
         const project = row.original;
         return (
-
-          <AlertDialog>
-            <AlertDialogTrigger asChild>
-              <button
-                disabled={project.status === 'CLOSED'}
-                className="disabled:opacity-40 disabled:cursor-not-allowed"
-              >
-                <TooltipComponent
-                  Icon={CircleX}
-                  tip="Close Project"
-                  iconStyle="text-red-500 hover:text-red-700 cursor-pointer"
-                  handleOnClick={() => { }
-                  }
-
-                />
-                {/* <CircleX size={16} strokeWidth={1.8} className="text-red-500 hover:text-red-700" /> */}
-              </button>
-            </AlertDialogTrigger>
-            <AlertDialogContent>
-              <AlertDialogHeader>
-                <AlertDialogTitle>Close &quot;{project.name}&quot;?</AlertDialogTitle>
-                <AlertDialogDescription>
-                  Are you sure you want to close this project? Once a project is
-                  closed, it cannot be reactivated.
-                </AlertDialogDescription>
-              </AlertDialogHeader>
-              <AlertDialogFooter>
-                <AlertDialogCancel>Cancel</AlertDialogCancel>
-                <AlertDialogAction
-                  className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-                  onClick={() => handleCloseProject(project.uuid as UUID)}
-                >
-                  {/* Confirm */}
-                  {closeProject.isPending ? 'Closing...' : 'Confirm'}
-
-                </AlertDialogAction>
-              </AlertDialogFooter>
-            </AlertDialogContent>
-          </AlertDialog>
+          <TooltipComponent
+            Icon={CircleX}
+            tip="Close Project"
+            iconStyle="text-red-500 hover:text-red-700 cursor-pointer"
+            disable={project.status === 'CLOSED'}
+            handleOnClick={() => setSelectedProject(project)}
+          />
         );
       },
     },
   ];
+
   const table = useReactTable({
-    manualPagination: true,
-    data: projects || [],
+    data: projects,
     columns,
+    state: { columnFilters },
+    onColumnFiltersChange: setColumnFilters,
     getCoreRowModel: getCoreRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    initialState: { pagination: { pageSize: 10, pageIndex: 0 } },
   });
+
+  const { pageIndex, pageSize } = table.getState().pagination;
+  const pageCount = table.getPageCount();
+  const filteredTotal = table.getFilteredRowModel().rows.length;
 
   return (
     <div className="p-6">
-      <h2 className="text-xl font-semibold mb-4">Projects</h2>
+      <div className="flex justify-between space-x-2 mb-2">
+        <SearchInput
+          className="w-full flex-[4]"
+          name="name"
+          onSearch={(e) => setFilter('name', e?.target?.value ?? '')}
+          value={getFilterValue('name') ?? ''}
+        />
+        <SelectComponent
+          name="Status"
+          options={['ALL', 'ACTIVE', 'NOT_READY', 'CLOSED']}
+          onChange={(value) => setFilter('status', value === 'ALL' ? '' : value)}
+          value={getFilterValue('status') || 'ALL'}
+          className="flex-[1]"
+        />
+      </div>
+
       <DemoTable
         table={table}
-        tableHeight={'h-[calc(100vh-320px)]'}
+        tableHeight="h-[calc(100vh-230px)]"
         loading={isLoading}
         message="No Projects Found"
       />
+
+      <CustomPagination
+        meta={{ lastPage: pageCount, total: filteredTotal } as any}
+        handleNextPage={() => table.nextPage()}
+        handlePrevPage={() => table.previousPage()}
+        handlePageSizeChange={(val) => table.setPageSize(Number(val))}
+        currentPage={pageIndex + 1}
+        perPage={pageSize}
+        total={filteredTotal}
+      />
+
+      <AlertDialog
+        open={!!selectedProject}
+        onOpenChange={(open) => !open && setSelectedProject(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Close &quot;{selectedProject?.name}&quot;?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Are you sure you want to close this project? Once a project is
+              closed, it cannot be reactivated.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              onClick={handleCloseProject}
+            >
+              {closeProject.isPending ? 'Closing...' : 'Confirm'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/apps/rahat-ui/src/sections/projects/projectList.tsx
+++ b/apps/rahat-ui/src/sections/projects/projectList.tsx
@@ -28,6 +28,8 @@ import { useState } from 'react';
 import SelectComponent from './comms/select.component';
 import CustomPagination from '../../components/customPagination';
 import TooltipWrapper from '../../components/tooltip.wrapper';
+import { dateFormat } from '../../utils/dateFormate';
+import { TruncatedCell } from './aa-2/stakeholders/component/TruncatedCell';
 
 export const STATUS_CONFIG: Record<string, { label: string; className: string }> = {
   NOT_READY: { label: 'Not Ready', className: 'bg-yellow-100 text-yellow-700 border-yellow-300' },
@@ -81,7 +83,9 @@ export default function ListProject() {
     {
       header: 'Description',
       accessorKey: 'description',
-      cell: ({ row }) => <div>{row.getValue('description')}</div>,
+      cell: ({ row }) => <div>
+        <TruncatedCell text={row.getValue('description')} />
+      </div>,
     },
     {
       header: 'Type',
@@ -99,7 +103,7 @@ export default function ListProject() {
       accessorKey: 'createdAt',
       cell: ({ row }) =>
         row.original.createdAt
-          ? new Date(row.original.createdAt).toLocaleDateString()
+          ? dateFormat(row.original.createdAt)
           : '—',
     },
     {

--- a/apps/rahat-ui/src/sections/settings/useNavItems.tsx
+++ b/apps/rahat-ui/src/sections/settings/useNavItems.tsx
@@ -33,6 +33,17 @@ export const useSettingFieldDefinitionNavItems = () => {
         },
       ],
     },
+    {
+      title: 'Project Info',
+      children: [
+        {
+          title: 'List',
+          path: '/project-info',
+          icon: <List size={18} strokeWidth={1.5} />,
+        },
+
+      ],
+    },
   ];
   return menuItems;
 };

--- a/libs/query/src/lib/projects/projects.service.ts
+++ b/libs/query/src/lib/projects/projects.service.ts
@@ -924,9 +924,7 @@ export const useProjectClose = () => {
           title: 'Project closed successfully',
           icon: 'success',
         });
-        queryClient.invalidateQueries({
-          queryKey: [TAGS.GET_PROJECT_DETAILS],
-        });
+        queryClient.invalidateQueries({ queryKey: [TAGS.GET_ALL_PROJECTS] });
       },
       onError: () => {
         toast.fire({

--- a/libs/query/src/lib/projects/projects.service.ts
+++ b/libs/query/src/lib/projects/projects.service.ts
@@ -663,20 +663,20 @@ export const useProjectBeneficiaries = (payload: GetProjectBeneficiaries) => {
         ...query.data,
         data: query.data?.data?.length
           ? query.data.data.map((row: any) => ({
-              ...row,
-              uuid: row?.uuid?.toString(),
-              walletAddress: row?.walletAddress?.toString(),
-              voucherClaimStatus: row?.claimStatus,
-              name: row?.piiData?.name || '',
-              email: row?.piiData?.email || '',
-              gender: row?.projectData?.gender?.toString() || '',
-              phone: row?.piiData?.phone || 'N/A',
-              type: row?.type?.toString() || 'N/A',
-              phoneStatus: row?.projectData?.phoneStatus || '',
-              bankedStatus: row?.projectData?.bankedStatus || '',
-              internetStatus: row?.projectData?.internetStatus || '',
-              benTokens: row?.benTokens || 'N/A',
-            }))
+            ...row,
+            uuid: row?.uuid?.toString(),
+            walletAddress: row?.walletAddress?.toString(),
+            voucherClaimStatus: row?.claimStatus,
+            name: row?.piiData?.name || '',
+            email: row?.piiData?.email || '',
+            gender: row?.projectData?.gender?.toString() || '',
+            phone: row?.piiData?.phone || 'N/A',
+            type: row?.type?.toString() || 'N/A',
+            phoneStatus: row?.projectData?.phoneStatus || '',
+            bankedStatus: row?.projectData?.bankedStatus || '',
+            internetStatus: row?.projectData?.internetStatus || '',
+            benTokens: row?.benTokens || 'N/A',
+          }))
           : [],
       };
     }, [query.data]),
@@ -902,6 +902,44 @@ export const useProjectEdit = () => {
       mutationKey: ['projectEdit'],
       mutationFn: async ({ uuid, data }: { uuid: UUID; data: any }) => {
         const res = await rumsanService.client.patch(`/projects/${uuid}`, data);
+        return res;
+      },
+    },
+    queryClient,
+  );
+};
+export const useProjectClose = () => {
+  const { queryClient, rumsanService } = useRSQuery();
+  const alert = useSwal();
+  const toast = alert.mixin({
+    toast: true,
+    position: 'top-end',
+    showConfirmButton: false,
+    timer: 3000,
+  });
+  return useMutation(
+    {
+      onSuccess: () => {
+        toast.fire({
+          title: 'Project closed successfully',
+          icon: 'success',
+        });
+        queryClient.invalidateQueries({
+          queryKey: [TAGS.GET_PROJECT_DETAILS],
+        });
+      },
+      onError: () => {
+        toast.fire({
+          title: 'Error while closing project.',
+          icon: 'error',
+        });
+      },
+      mutationKey: ['projectClose'],
+      mutationFn: async ({ uuid, data }: { uuid: UUID; data: { status: string } }) => {
+        const res = await rumsanService.client.patch(
+          `/projects/${uuid}/status`,
+          data,
+        );
         return res;
       },
     },


### PR DESCRIPTION
## 🔗 Related Issue

<!-- Link issue (if any) -->
- https://github.com/rahataid/rahat-ui/issues/2353
- [x] Added issue link

## 📌 Description

<!-- What does this PR do? Explain clearly -->

- Implements the Project Close feature across the UI with the following changes:
- Adds a new Project Info page under Core Settings.
- Displays a list of all available projects along with their current status.
- Adds a Close Project button for each project (e.g., project-aa-heatwave).
- Displays a confirmation modal before closing a project.
- Displays the project status using badge components with meaningful colors
- Displays a persistent notification/banner in the navigation bar when the current project is closed.
- Hides connect wallet button form navbar if project type is aa inside project
- If a user attempts to perform a restricted action on a closed project, displays the error message returned by the API in a clear and user-friendly manner.
- Implemented Search by name, Status Filter and Pagination in project list page
- [Demo](https://www.awesomescreenshot.com/video/54057415?key=4888053bcf92acba01279a71cb488107)

---

## ✅ Checklist

- [x] No `console.log` or debug code left
- [x] Proper error handling implemented
- [x] Loading states handled (if needed)
- [x] API calls handled safely
- [x] No unnecessary code or comments
- [x] Self-reviewed code for logic, edge cases, and potential issues

---

## 🎯 Type of Change

- [ ] Bug fix
- [x] New feature
- [x] UI update
- [ ] Refactor
- [ ] Performance improvement

---

## 📸 Before / After

### Before

## <!-- Add screenshots -->
<img width="1470" height="836" alt="before-1" src="https://github.com/user-attachments/assets/97bf9b9b-f334-498d-b1e1-880c7aa3944d" />
<img width="1470" height="833" alt="before-2" src="https://github.com/user-attachments/assets/d504220f-8aeb-4bfb-a05b-95d7ef3d4216" />
<img width="1470" height="823" alt="before-3" src="https://github.com/user-attachments/assets/5b848b3a-a173-460f-b3e0-e13d016d6fe5" />


### After

## <!-- Add screenshots -->
<img width="1470" height="830" alt="project-close-dialog" src="https://github.com/user-attachments/assets/8f6bd26a-4597-49ae-8a06-90107e1c189a" />
<img width="1470" height="835" alt="project-closure-alert" src="https://github.com/user-attachments/assets/ef250d1f-ea78-41a3-87f9-3f03b1155a27" />
<img width="1470" height="835" alt="project-status-main-page" src="https://github.com/user-attachments/assets/7d38b027-f99c-4822-8265-b7c624f37911" />
<img width="1470" height="832" alt="project-table-after-close" src="https://github.com/user-attachments/assets/6ca83780-e12f-42c7-9675-5157c92e57f5" />

---

## 🧪 How to Test

<!-- Steps to test this PR -->

1.Go to Setting page in core
2. Click on List in project in sidebar
3. Perform the project close feature
4. Go inside the project ,you will see a alert message showing project close message

---

## ⚠️ Notes for Reviewer

<!-- Anything special reviewer should know -->

- Test Properly
- Since ,there is no pagination code in getting projects service i have integrated the  front end pagination.
