### PR TITLE
fix: disable Add Activity when no phases exist and Download Report when no activities exist

### DIFF
--- a/apps/rahat-ui/src/sections/projects/aa-2/activities/main.tsx
+++ b/apps/rahat-ui/src/sections/projects/aa-2/activities/main.tsx
@@ -13,6 +13,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useSidebar } from '@rahat-ui/shadcn/src/components/ui/sidebar';
 import { Card, CardContent } from '@rahat-ui/shadcn/src/components/ui/card';
 import { Button } from '@rahat-ui/shadcn/src/components/ui/button';
+import TooltipWrapper from 'apps/rahat-ui/src/components/tooltip.wrapper';
 
 export default function ActivitiesView() {
   const { id: projectID } = useParams();
@@ -21,6 +22,7 @@ export default function ActivitiesView() {
   const { activitiesData, isLoading } = useActivities(projectID as UUID, {
     perPage: 9999,
   });
+  const hasActivities = (activitiesData?.length ?? 0) > 0;
 
   usePhases(projectID as UUID);
 
@@ -115,7 +117,7 @@ export default function ActivitiesView() {
     const unpinned = uniquePhases.filter((p) => !pinnedPhases.includes(p));
     return [...pinned, ...unpinned];
   }, [pinnedPhases, uniquePhases]);
-
+  const hasPhases = sortedPhases.length > 0;
   const phaseDataMap = useMemo(() => {
     const map: Record<string, IActivitiesItem[]> = {};
     if (!activitiesData) return map;
@@ -146,7 +148,7 @@ export default function ActivitiesView() {
         const [leadTimeValue, leadTimeUnit] = (item.leadTime || '').split(' ');
         return {
           'Activity Title': item.title || 'N/A',
-          'Category': item.category || 'N/A',
+          Category: item.category || 'N/A',
           Phase: item.phase || 'N/A',
           Type: item.isAutomated ? 'Automated' : 'Manual',
           Responsibility: item.responsibility,
@@ -184,27 +186,43 @@ export default function ActivitiesView() {
               roles={[AARoles.ADMIN, AARoles.MANAGER, AARoles.Municipality]}
               hasContent={false}
             >
-              <IconLabelBtn
-                Icon={CloudDownloadIcon}
-                handleClick={handleDownloadReport}
-                name="Download Report"
-                variant="outline"
-              />
+              <TooltipWrapper
+                tip={
+                  !hasActivities
+                    ? 'Create an activity before downloading the report.'
+                    : ''
+                }
+              >
+                <IconLabelBtn
+                  Icon={CloudDownloadIcon}
+                  handleClick={handleDownloadReport}
+                  name="Download Report"
+                  variant="outline"
+                  disabled={!hasActivities}
+                />
+              </TooltipWrapper>
             </RoleAuth>
             <RoleAuth
               roles={[AARoles.ADMIN, AARoles.MANAGER, AARoles.Municipality]}
               hasContent={false}
             >
-              <IconLabelBtn
-                Icon={Plus}
-                handleClick={() =>
-                  router.push(
-                    `/projects/aa/${projectID}/activities/add?nav=mainPage`,
-                  )
+              <TooltipWrapper
+                tip={
+                  !hasPhases ? 'Create a phase before adding activities.' : ''
                 }
-                name="Add Activity"
-                variant="default"
-              />
+              >
+                <IconLabelBtn
+                  Icon={Plus}
+                  handleClick={() =>
+                    router.push(
+                      `/projects/aa/${projectID}/activities/add?nav=mainPage`,
+                    )
+                  }
+                  name="Add Activity"
+                  variant="default"
+                  disabled={!hasPhases}
+                />
+              </TooltipWrapper>
             </RoleAuth>
           </div>
         </div>

--- a/apps/rahat-ui/src/sections/projects/aa-2/activities/main.tsx
+++ b/apps/rahat-ui/src/sections/projects/aa-2/activities/main.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { useActivities, usePhases, usePhasesStore } from '@rahat-ui/query';
-import { Heading, IconLabelBtn } from 'apps/rahat-ui/src/common';
+import { Heading, IconLabelBtn, NoResult } from 'apps/rahat-ui/src/common';
 import { generateExcel } from 'apps/rahat-ui/src/utils';
 import { IActivitiesItem } from 'apps/rahat-ui/src/types/activities';
 import { UUID } from 'crypto';
@@ -226,62 +226,68 @@ export default function ActivitiesView() {
             </RoleAuth>
           </div>
         </div>
-        <div
-          className={`flex gap-4 ${
-            state === 'expanded'
-              ? 'w-[calc(100vw-18rem)]'
-              : 'w-[calc(100vw-5rem)]'
-          } transition-[width] duration-300 overflow-x-auto  [&::-webkit-scrollbar]:h-1.5  [&::-webkit-scrollbar-track]:rounded-full [&::-webkit-scrollbar-track]:bg-gray-100 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-gray-300`}
-          style={{ scrollbarGutter: 'stable' }}
-        >
-          {sortedPhases.map((phase) => (
-            <div key={phase} className="min-w-[320px] w-full">
-              <PhaseContent
-                title={phase.charAt(0) + phase.slice(1).toLowerCase()}
-                description={
-                  PHASE_DESCRIPTIONS[phase] ??
-                  `Overview of ${phase.toLowerCase()} phase`
-                }
-                phases={phaseDataMap[phase] ?? []}
-                loading={isLoading}
-                isPinned={pinnedPhases.includes(phase)}
-                onTogglePin={() => togglePin(phase)}
-              />
-            </div>
-          ))}
-          {sortedPhases.length === 2 && (
-            <RoleAuth
-              roles={[AARoles.ADMIN, AARoles.Municipality]}
-              hasContent={false}
-            >
-              <div className="min-w-[320px]">
-                <Card className="flex flex-col rounded-xl h-[calc(100vh-180px)] w-full items-center justify-center border-dashed border-2 border-blue-300 bg-gray-50">
-                  <CardContent className="flex flex-col items-center justify-center gap-4 p-6 text-center">
-                    <div className="flex flex-col gap-1 items-center ">
-                      <Button
-                        onClick={handleAddPhase}
-                        className="flex items-center justify-center w-10 h-10 rounded-full bg-gray-100"
-                      >
-                        <div className="flex items-center justify-center w-4 h-4">
-                          <Plus
-                            className="  text-blue-500 hover:text-white"
-                            size={'2rem'}
-                          />
-                        </div>
-                      </Button>
-                      <p className="text-base font-medium text-blue-500 ">
-                        Add Phase
-                      </p>
-                      <p className="text-sm text-blue-400">
-                        Click here to add new phase
-                      </p>
-                    </div>
-                  </CardContent>
-                </Card>
+        {!hasPhases ? (
+          <div className="w-full flex items-center justify-center h-[calc(100vh-180px)]">
+            <NoResult message="No Data Available" />
+          </div>
+        ) : (
+          <div
+            className={`flex gap-4 ${
+              state === 'expanded'
+                ? 'w-[calc(100vw-18rem)]'
+                : 'w-[calc(100vw-5rem)]'
+            } transition-[width] duration-300 overflow-x-auto  [&::-webkit-scrollbar]:h-1.5  [&::-webkit-scrollbar-track]:rounded-full [&::-webkit-scrollbar-track]:bg-gray-100 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-gray-300`}
+            style={{ scrollbarGutter: 'stable' }}
+          >
+            {sortedPhases.map((phase) => (
+              <div key={phase} className="min-w-[320px] w-full">
+                <PhaseContent
+                  title={phase.charAt(0) + phase.slice(1).toLowerCase()}
+                  description={
+                    PHASE_DESCRIPTIONS[phase] ??
+                    `Overview of ${phase.toLowerCase()} phase`
+                  }
+                  phases={phaseDataMap[phase] ?? []}
+                  loading={isLoading}
+                  isPinned={pinnedPhases.includes(phase)}
+                  onTogglePin={() => togglePin(phase)}
+                />
               </div>
-            </RoleAuth>
-          )}
-        </div>
+            ))}
+            {sortedPhases.length === 2 && (
+              <RoleAuth
+                roles={[AARoles.ADMIN, AARoles.Municipality]}
+                hasContent={false}
+              >
+                <div className="min-w-[320px]">
+                  <Card className="flex flex-col rounded-xl h-[calc(100vh-180px)] w-full items-center justify-center border-dashed border-2 border-blue-300 bg-gray-50">
+                    <CardContent className="flex flex-col items-center justify-center gap-4 p-6 text-center">
+                      <div className="flex flex-col gap-1 items-center ">
+                        <Button
+                          onClick={handleAddPhase}
+                          className="flex items-center justify-center w-10 h-10 rounded-full bg-gray-100"
+                        >
+                          <div className="flex items-center justify-center w-4 h-4">
+                            <Plus
+                              className="  text-blue-500 hover:text-white"
+                              size={'2rem'}
+                            />
+                          </div>
+                        </Button>
+                        <p className="text-base font-medium text-blue-500 ">
+                          Add Phase
+                        </p>
+                        <p className="text-sm text-blue-400">
+                          Click here to add new phase
+                        </p>
+                      </div>
+                    </CardContent>
+                  </Card>
+                </div>
+              </RoleAuth>
+            )}
+          </div>
+        )}
       </div>
     </>
   );

--- a/apps/rahat-ui/src/sections/projects/aa-2/activities/main.tsx
+++ b/apps/rahat-ui/src/sections/projects/aa-2/activities/main.tsx
@@ -228,7 +228,7 @@ export default function ActivitiesView() {
         </div>
         {!hasPhases ? (
           <div className="w-full flex items-center justify-center h-[calc(100vh-180px)]">
-            <NoResult message="No Data Available" />
+            <NoResult message="No phases available. Create a phase to add activities." />
           </div>
         ) : (
           <div

--- a/apps/rahat-ui/src/sections/projects/aa-2/triggerStatement/main.tsx
+++ b/apps/rahat-ui/src/sections/projects/aa-2/triggerStatement/main.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Heading } from 'apps/rahat-ui/src/common';
+import { Heading, NoResult } from 'apps/rahat-ui/src/common';
 import { TriggersListCard, TriggersPhaseCard } from './components';
 import { ScrollArea } from '@rahat-ui/shadcn/src/components/ui/scroll-area';
 import { useParams, useRouter } from 'next/navigation';
@@ -127,73 +127,80 @@ export default function TriggerStatementView() {
           />
         </RoleAuth>
       </div>
+
       <div className="flex gap-1 flex-1 overflow-hidden mt-4">
         {/* Left section – phase cards in a 2-column grid, scrollable */}
         <ScrollArea className="flex-1 ">
-          <div className="grid grid-cols-2 gap-4 pr-2">
-            {sortedPhases.map((d) => (
-              <TriggersPhaseCard
-                key={d.id}
-                title={d.name}
-                subtitle={`Overview of ${d.name.toLowerCase()} phase`}
-                handleAddTrigger={() => handleAddTrigger(d)}
-                chartLabels={['Mandatory', 'Optional']}
-                chartSeries={[
-                  d?.phaseStats?.totalMandatoryTriggers || 0,
-                  d?.phaseStats?.totalOptionalTriggers || 0,
-                ]}
-                requiredMandatoryTriggers={d?.requiredMandatoryTriggers || 0}
-                requiredOptionalTriggers={d?.requiredOptionalTriggers || 0}
-                mandatoryTriggers={d?.phaseStats?.totalMandatoryTriggers || 0}
-                optionalTriggers={d?.phaseStats?.totalOptionalTriggers || 0}
-                triggeredMandatoryTriggers={
-                  d?.phaseStats?.totalMandatoryTriggersTriggered || 0
-                }
-                triggeredOptionalTriggers={
-                  d?.phaseStats?.totalOptionalTriggersTriggered || 0
-                }
-                handleViewDetails={() => handleViewDetails(d)}
-                isActive={d?.isActive}
-                isPinned={pinnedPhaseIds.includes(d.uuid)}
-                onTogglePin={() => togglePinPhase(d.uuid)}
-                hasExtendedLogic={!!d?.extendedTriggerLogic}
-              />
-            ))}
+          {sortedPhases.length === 0 ? (
+            <div className="flex h-full min-h-[400px] items-center justify-center">
+              <NoResult message="No Phases Available" />
+            </div>
+          ) : (
+            <div className="grid grid-cols-2 gap-4 pr-2">
+              {sortedPhases.map((d) => (
+                <TriggersPhaseCard
+                  key={d.id}
+                  title={d.name}
+                  subtitle={`Overview of ${d.name.toLowerCase()} phase`}
+                  handleAddTrigger={() => handleAddTrigger(d)}
+                  chartLabels={['Mandatory', 'Optional']}
+                  chartSeries={[
+                    d?.phaseStats?.totalMandatoryTriggers || 0,
+                    d?.phaseStats?.totalOptionalTriggers || 0,
+                  ]}
+                  requiredMandatoryTriggers={d?.requiredMandatoryTriggers || 0}
+                  requiredOptionalTriggers={d?.requiredOptionalTriggers || 0}
+                  mandatoryTriggers={d?.phaseStats?.totalMandatoryTriggers || 0}
+                  optionalTriggers={d?.phaseStats?.totalOptionalTriggers || 0}
+                  triggeredMandatoryTriggers={
+                    d?.phaseStats?.totalMandatoryTriggersTriggered || 0
+                  }
+                  triggeredOptionalTriggers={
+                    d?.phaseStats?.totalOptionalTriggersTriggered || 0
+                  }
+                  handleViewDetails={() => handleViewDetails(d)}
+                  isActive={d?.isActive}
+                  isPinned={pinnedPhaseIds.includes(d.uuid)}
+                  onTogglePin={() => togglePinPhase(d.uuid)}
+                  hasExtendedLogic={!!d?.extendedTriggerLogic}
+                />
+              ))}
 
-            {sortedPhases.length === 3 && (
-              <RoleAuth
-                roles={[AARoles.ADMIN, AARoles.Municipality]}
-                hasContent={false}
-              >
-                <div>
-                  <Card className="flex flex-col rounded-xl h-full min-h-[calc(100vh-410px)] w-full items-center justify-center border-dashed border-2 border-blue-300 bg-gray-50">
-                    <CardContent className="flex flex-col items-center justify-center gap-4 p-6 text-center">
-                      <div className="flex flex-col gap-1 items-center ">
-                        <Button
-                          onClick={handleAddPhase}
-                          className="flex items-center justify-center w-10 h-10 rounded-full bg-gray-100"
-                        >
-                          <div className="flex items-center justify-center w-4 h-4">
-                            <Plus
-                              className="  text-blue-500 hover:text-white"
-                              size={'2rem'}
-                            />
-                          </div>
-                        </Button>
-                        <p className="text-base font-medium text-blue-500 ">
-                          Add Phase
-                        </p>
-                        <p className="text-sm text-blue-400">
-                          Click here to add new phase
-                        </p>
-                      </div>
-                    </CardContent>
-                  </Card>
-                </div>
-              </RoleAuth>
-            )}
-            {/* } */}
-          </div>
+              {sortedPhases.length === 3 && (
+                <RoleAuth
+                  roles={[AARoles.ADMIN, AARoles.Municipality]}
+                  hasContent={false}
+                >
+                  <div>
+                    <Card className="flex flex-col rounded-xl h-full min-h-[calc(100vh-410px)] w-full items-center justify-center border-dashed border-2 border-blue-300 bg-gray-50">
+                      <CardContent className="flex flex-col items-center justify-center gap-4 p-6 text-center">
+                        <div className="flex flex-col gap-1 items-center ">
+                          <Button
+                            onClick={handleAddPhase}
+                            className="flex items-center justify-center w-10 h-10 rounded-full bg-gray-100"
+                          >
+                            <div className="flex items-center justify-center w-4 h-4">
+                              <Plus
+                                className="  text-blue-500 hover:text-white"
+                                size={'2rem'}
+                              />
+                            </div>
+                          </Button>
+                          <p className="text-base font-medium text-blue-500 ">
+                            Add Phase
+                          </p>
+                          <p className="text-sm text-blue-400">
+                            Click here to add new phase
+                          </p>
+                        </div>
+                      </CardContent>
+                    </Card>
+                  </div>
+                </RoleAuth>
+              )}
+              {/* } */}
+            </div>
+          )}
         </ScrollArea>
 
         {/* Right section – recent triggers list */}


### PR DESCRIPTION
## 🔗 Related Issue

https://github.com/rahataid/rahat-ui/issues/2099
https://github.com/rahataid/rahat-ui/issues/2078

- [x] Added issue link

## 📌 Description

- Disabled the Add Activity button when no phases are available and added a tooltip explaining that a phase must be created first.
- Disabled the Download Report button when no activities are available and added a tooltip explaining that activities are required before downloading a report.
- Added an empty state to the Activities and Trigger Statement pages when no phases are available.
- Prevented users from attempting actions that cannot be completed due to missing prerequisite data.

---

## ✅ Checklist

- [x] No `console.log` or debug code left
- [ ] Proper error handling implemented
- [ ] Loading states handled (if needed)
- [ ] API calls handled safely
- [x] No unnecessary code or comments
- [x] Self-reviewed code for logic, edge cases, and potential issues

---

## 🎯 Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] UI update
- [ ] Refactor
- [ ] Performance improvement

---

## 📸 Before / After

### Before

<img width="2878" height="1342" alt="image" src="https://github.com/user-attachments/assets/434a6e38-3a64-40a3-87f0-8dc924cfba3b" />

### After

<img width="1453" height="502" alt="image" src="https://github.com/user-attachments/assets/74636ba8-c8f0-429e-a2bd-01d6809de968" />

<img width="1453" height="502" alt="image" src="https://github.com/user-attachments/assets/8a40b8c7-cb77-495a-a6c0-48210c314f70" />

<img width="1710" height="1069" alt="image" src="https://github.com/user-attachments/assets/bce13d1b-fab5-4fde-8e58-c212f33a35b6" />

<img width="1710" height="1069" alt="image" src="https://github.com/user-attachments/assets/ffb0bb8e-da3e-475e-8515-7d6d5752f4fd" />

---

## 🧪 How to Test

1. Open a project with no phases.
2. Verify the Activities page displays an empty state indicating that no phases are available.
3. Verify the Trigger Statement page displays an empty state indicating that no phases are available.
4. Verify the Add Activity button is disabled and displays a tooltip explaining that a phase must be created first.
5. Create a phase and verify the Add Activity button becomes enabled.
6. Ensure the project has no activities.
7. Verify the Download Report button is disabled and displays a tooltip explaining that activities are required before downloading.
8. Add an activity and verify the Download Report button becomes enabled and downloads the report successfully.

---

## ⚠️ Notes for Reviewer

1. The Add Activity button is enabled based on the availability of phases.
2. The Download Report button is enabled based on the availability of activities.
3. Tooltips have been added to explain why each action is disabled.
4. Empty states are shown on the Activities and Trigger Statement pages when no phases exist.
