### PR TITLE
fix(activity): prevent activity update until communication changes are saved

### DIFF
--- a/apps/rahat-ui/src/sections/projects/aa-2/activities/add/add.activity.view.tsx
+++ b/apps/rahat-ui/src/sections/projects/aa-2/activities/add/add.activity.view.tsx
@@ -519,6 +519,7 @@ export default function AddActivities() {
                         uploadFile?.isPending ||
                         audioUploading.value ||
                         addCommunicationOpen.value ||
+                        editCommunicationOpen.value ||
                         !!form.formState.errors.responsibility
                       }
                     >

--- a/apps/rahat-ui/src/sections/projects/aa-2/activities/edit/activity.edit.view.tsx
+++ b/apps/rahat-ui/src/sections/projects/aa-2/activities/edit/activity.edit.view.tsx
@@ -124,8 +124,9 @@ export default function EditActivity() {
 
   const redirectUpdatePath = redirectTo
     ? `/projects/aa/${projectID}/activities/${activityID}`
-    : `/projects/aa/${projectID}/activities/${activityID}${backFrom ? `?from=${backFrom}` : ''
-    }`;
+    : `/projects/aa/${projectID}/activities/${activityID}${
+        backFrom ? `?from=${backFrom}` : ''
+      }`;
 
   const { FormSchema, form, communicationForm, defaultCommunicationValues } =
     useActivityForm(appTransports);
@@ -415,7 +416,9 @@ export default function EditActivity() {
                         updateActivity?.isPending ||
                         uploadFile?.isPending ||
                         audioUploading ||
-                        open
+                        open ||
+                        editCommunicationForm.value ||
+                        !!form.formState.errors.responsibility
                       }
                     >
                       Update
@@ -698,7 +701,7 @@ export default function EditActivity() {
                               className="bg-white shadow-sm rounded-xl p-4 border border-gray-200 flex items-center gap-3 hover:cursor-pointer hover:bg-gray-100"
                             >
                               {uploadFile.isPending &&
-                                uploadingFileName === file.fileName ? (
+                              uploadingFileName === file.fileName ? (
                                 <LoaderCircle className="text-green-600 animate-spin w-9 h-9" />
                               ) : (
                                 <FileCheck className="w-9 h-9 text-green-600" />

--- a/apps/rahat-ui/src/sections/projects/aa-2/activities/edit/activity.edit.view.tsx
+++ b/apps/rahat-ui/src/sections/projects/aa-2/activities/edit/activity.edit.view.tsx
@@ -284,29 +284,25 @@ export default function EditActivity() {
     if (typeof window === 'undefined') return;
     if (isActivityLoading) return;
 
-    if (isAddComm) {
-      // Wait till the component is fully rendered before opening the form and scrolling
-      setTimeout(() => {
-        setOpen(true);
-      }, 100);
+    const shouldOpen = isAddComm || editCommunicationForm.value;
 
-      setTimeout(() => {
-        if (!scrollAreaRef.current) return;
+    if (!shouldOpen) return;
+    if (shouldOpen) {
+      if (!scrollAreaRef.current) return;
 
-        // Needed as scroll viewport is defined and scrollAreaRef is inside the viewport
-        const viewport = scrollAreaRef.current.closest(
-          '[data-radix-scroll-area-viewport]',
-        );
+      // Needed as scroll viewport is defined and scrollAreaRef is inside the viewport
+      const viewport = scrollAreaRef.current.closest(
+        '[data-radix-scroll-area-viewport]',
+      );
 
-        if (viewport) {
-          viewport.scrollTo({
-            top: scrollAreaRef.current.offsetTop,
-            behavior: 'smooth',
-          });
-        }
-      }, 500);
+      if (viewport) {
+        viewport.scrollTo({
+          top: scrollAreaRef.current.offsetTop,
+          behavior: 'smooth',
+        });
+      }
     }
-  }, [isActivityLoading, isAddComm]);
+  }, [isActivityLoading, isAddComm, editCommunicationForm.value]);
 
   // this will set default values when activity detail is loaded
   useEffect(() => {

--- a/apps/rahat-ui/src/sections/projects/aa-2/activities/edit/activity.edit.view.tsx
+++ b/apps/rahat-ui/src/sections/projects/aa-2/activities/edit/activity.edit.view.tsx
@@ -87,7 +87,6 @@ export default function EditActivity() {
   const redirectTo = searchParams.get('from');
   const editCommunicationForm = useBoolean();
 
-  const isAddComm = window.location.hash === '#comm';
   // Query goes here
   const { data: users } = useUserList({
     page: 1,
@@ -284,9 +283,8 @@ export default function EditActivity() {
     if (typeof window === 'undefined') return;
     if (isActivityLoading) return;
 
-    const shouldOpen = isAddComm || editCommunicationForm.value;
+    const shouldOpen = open || editCommunicationForm.value;
 
-    if (!shouldOpen) return;
     if (shouldOpen) {
       if (!scrollAreaRef.current) return;
 
@@ -302,7 +300,7 @@ export default function EditActivity() {
         });
       }
     }
-  }, [isActivityLoading, isAddComm, editCommunicationForm.value]);
+  }, [isActivityLoading, open, editCommunicationForm.value]);
 
   // this will set default values when activity detail is loaded
   useEffect(() => {
@@ -329,6 +327,14 @@ export default function EditActivity() {
       setCommunicationData(transformedData);
     }
   }, [activityDetail, form, appTransports]);
+
+  const isSubmitButtonDisabled =
+    updateActivity?.isPending ||
+    uploadFile?.isPending ||
+    audioUploading ||
+    open ||
+    editCommunicationForm.value ||
+    !!form.formState.errors.responsibility;
 
   // this code need to be removed after testing
   // const isVoiceAudioMissing = communicationData.some((comm) => {
@@ -408,14 +414,7 @@ export default function EditActivity() {
                     <Button
                       className="  w-36"
                       type="submit"
-                      disabled={
-                        updateActivity?.isPending ||
-                        uploadFile?.isPending ||
-                        audioUploading ||
-                        open ||
-                        editCommunicationForm.value ||
-                        !!form.formState.errors.responsibility
-                      }
+                      disabled={isSubmitButtonDisabled}
                     >
                       Update
                     </Button>
@@ -748,7 +747,7 @@ export default function EditActivity() {
                     onSave={handleSave}
                     setLoading={setAudioUploading}
                     appTransports={appTransports}
-                    isMultiSelect={isAddComm}
+                    isMultiSelect={open}
                     editMode={editCommunicationForm}
                   />
                 )}


### PR DESCRIPTION
## 🔗 Related Issue

https://github.com/rahataid/rahat-ui/issues/2204
- [x] Added issue link

## 📌 Description

This PR fixes two issues related to editing communications within an activity.

### 1. Prevent activity updates while a communication is being edited

Previously, if a user edited a communication, modified its fields (for example, clearing the required communication title), and clicked **Update Activity** without first saving the communication, the activity was submitted with an incomplete communication payload. This could result in the communication being removed unintentionally.

Changes made:
- Disabled the **Update Activity** button while a communication is in edit mode.
- Kept the activity update action disabled until the communication changes are saved or editing is cancelled.
- Prevented activity updates with unsaved communication changes.

### 2. Automatically navigate to the communication edit form

The communication edit form is displayed above the communication list. Previously, when editing a communication from a long list, the form opened correctly but remained outside the visible area, requiring users to manually scroll to continue editing.

Changes made:
- Automatically scroll to the communication edit form when **Edit** is clicked.
- Ensured the form is immediately visible, providing a smoother editing experience.

---

## ✅ Checklist

- [x] No `console.log` or debug code left
- [ ] Proper error handling implemented
- [ ] Loading states handled (if needed)
- [ ] API calls handled safely
- [x] No unnecessary code or comments
- [x] Self-reviewed code for logic, edge cases, and potential issues

---

## 🎯 Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] UI update
- [ ] Refactor
- [ ] Performance improvement

---

## 📸 Before / After

### Before

<img width="1453" height="980" alt="image" src="https://github.com/user-attachments/assets/9561f8d1-b666-4947-b985-24d9b06fcc29" />

### After

<img width="1453" height="980" alt="image" src="https://github.com/user-attachments/assets/80097a51-8dc1-4bc8-b84d-729c6cbe2583" />

<img width="1453" height="980" alt="image" src="https://github.com/user-attachments/assets/b38aa214-d366-436e-b314-fff0ef3cd5a2" />


### Video for Automatically navigate to the communication edit form

https://jam.dev/c/c48e2b9e-102c-45ee-bb90-612356e06517

---

## 🧪 How to Test

1. Open an existing activity that contains at least one communication.
2. Click Edit on a communication.
3. Modify any communication field (e.g., clear the communication title).
4. Verify that the Update Activity button remains disabled.
5. Save or cancel the communication edit.
6. Verify that the Update Activity button is enabled again and the activity can be updated normally.

---

## ⚠️ Notes for Reviewer

- This change only affects the activity update flow when a communication is in edit mode.