### PR TITLE
Poll bank validation details for ui with error refetch

### DIFF
--- a/apps/rahat-ui/src/sections/beneficiary/groups/groups.detail.tsx
+++ b/apps/rahat-ui/src/sections/beneficiary/groups/groups.detail.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import {
   CloudDownloadIcon,
   LandmarkIcon,
+  Loader2,
   Trash2Icon,
   UsersRound,
   Phone,
@@ -19,6 +20,7 @@ import {
 } from '@tanstack/react-table';
 import {
   useExportBeneficiariesFailedBankAccount,
+  useGetBankCheckStatus,
   useGetBeneficiaryGroup,
   usePagination,
 } from '@rahat-ui/query';
@@ -84,6 +86,9 @@ export default function GroupDetailView() {
 
   const groupedBeneficiaries = [] as any;
   const { data: group, isLoading } = useGetBeneficiaryGroup(Id);
+
+  const isBankTransfer = group?.data?.groupPurpose === GroupPurpose.BANK_TRANSFER;
+  const { data: bankCheckStatus } = useGetBankCheckStatus(Id, isBankTransfer);
   const [columnVisibility, setColumnVisibility] =
     React.useState<VisibilityState>({});
   const tableData = React.useMemo(() => {
@@ -308,7 +313,7 @@ export default function GroupDetailView() {
               )}
           </div>
         </div>
-        <div className="flex gap-4">
+        <div className="flex gap-4 items-start">
           <DataCard
             className="border-solid w-1/3 rounded-xl"
             iconStyle="bg-white text-secondary-muted"
@@ -336,6 +341,23 @@ export default function GroupDetailView() {
                 )}
               </div>
             </DataCard>
+          )}
+          {isBankTransfer && bankCheckStatus && (
+            <div className="border-solid w-1/3 rounded-xl border p-4 text-sm leading-snug">
+              {bankCheckStatus.pending > 0 ? (
+                <>
+                  <p className="text-muted-foreground font-medium mb-1 flex items-center gap-1">
+                    <Loader2 className="w-3 h-3 animate-spin" />
+                    Bank validation in progress
+                  </p>
+                  <p>Current status: <span className="font-medium">{bankCheckStatus.total - bankCheckStatus.pending}/{bankCheckStatus.total}</span></p>
+                </>
+              ) : (
+                <p className="text-muted-foreground font-medium mb-1">Bank validation completed</p>
+              )}
+              <p className="text-green-600">Success: {bankCheckStatus.success}</p>
+              <p className="text-red-500">Failed: {bankCheckStatus.failed}</p>
+            </div>
           )}
         </div>
 

--- a/apps/rahat-ui/src/sections/beneficiary/groups/validateAccountModal.tsx
+++ b/apps/rahat-ui/src/sections/beneficiary/groups/validateAccountModal.tsx
@@ -49,8 +49,8 @@ export default function ValidateBenefBankAccountByGroupUuid({
   };
 
   React.useEffect(() => {
-    validateBenefGroup.isSuccess && validateModal.onFalse();
-  }, [validateBenefGroup]);
+    if (validateBenefGroup.isSuccess) validateModal.onFalse();
+  }, [validateBenefGroup.isSuccess]);
 
   return (
     <Dialog open={validateModal.value} onOpenChange={validateModal.onToggle}>

--- a/libs/query/src/lib/beneficiary/beneficiary.service.ts
+++ b/libs/query/src/lib/beneficiary/beneficiary.service.ts
@@ -320,8 +320,9 @@ export const useValidateBeneficaryBankAccount = () => {
   });
   return useMutation({
     mutationFn: (payload: any) => validateBeneficiaryBankAccount(payload),
-    onSuccess: async () => {
+    onSuccess: async (_data, uuid) => {
       await qc.invalidateQueries({ queryKey: [TAGS.VALIDATE_BENEFICIARIES] });
+      qc.removeQueries({ queryKey: ['BANK_CHECK_STATUS', uuid] });
       toast.fire({
         title: 'Accounts check in progress. Data will be listed soon',
         icon: 'success',
@@ -738,6 +739,34 @@ export const useGetBeneficiaryGroup = (
     },
     queryClient,
   );
+};
+
+const getBankCheckStatus = async (uuid: UUID) => {
+  const response = await api.get(`/beneficiaries/groups/${uuid}/bank-check-status`);
+  return response?.data?.data;
+};
+
+export const useGetBankCheckStatus = (uuid: UUID, isBankTransfer: boolean) => {
+  const qc = useQueryClient();
+
+  const query = useQuery({
+    queryKey: ['BANK_CHECK_STATUS', uuid],
+    queryFn: () => getBankCheckStatus(uuid),
+    enabled: !!uuid && isBankTransfer,
+    refetchInterval: (q) => {
+      const d = q.state.data;
+      if (!d || d.pending === 0) return false;
+      return 5000;
+    },
+  });
+
+  useEffect(() => {
+    if (query.data) {
+      qc.invalidateQueries({ queryKey: [GET_BENEFICIARY_GROUP, uuid] });
+    }
+  }, [query.data]);
+
+  return query;
 };
 
 export const useExportBeneficiariesFailedBankAccount = (


### PR DESCRIPTION
# Poll Bank Validation Status in Beneficiary Group Detail

## 📌 Description
- Poll `GET /beneficiaries/groups/:uuid/bank-check-status` every 5s while validation is in progress
- Show a status card inline with the data cards (total/success/failed/pending) — only for `BANK_TRANSFER` groups
- Display spinning loader and "in progress" state while `pending > 0`, "completed" state when done
- Each poll also refetches the group detail (`/beneficiaries/groups/:uuid`) to refresh error texts on beneficiaries
- Polling stops automatically when `pending === 0`; restarts on new validation trigger

## ✅ Checklist
- [x] No console.log or debug code left
- [x] Proper error handling implemented
- [x] Loading states handled
- [x] API calls handled safely
- [x] No unnecessary code or comments
- [x] Self-reviewed code for logic, edge cases, and potential issues

## Image
<img width="927" height="455" alt="image" src="https://github.com/user-attachments/assets/03465ce3-2351-4761-b5fa-cd70319ccd98" />

## 🎯 Type of Change
- [x] UI update
- [x] New feature (bank validation status polling)

## 🧪 How to Test
1. Open a beneficiary group with `groupPurpose: BANK_TRANSFER`
2. Press **Validate Bank Account** and confirm
3. Verify status card appears inline with Total Beneficiaries card showing current progress
4. Verify spinner shows while pending > 0, "Bank validation completed" when done
5. Navigate away and back — verify polling resumes if validation was in progress
6. Open a group with a different purpose — verify no status card and no polling

## 📝 Files Modified
- `apps/rahat-ui/src/sections/beneficiary/groups/groups.detail.tsx`
- `apps/rahat-ui/src/sections/beneficiary/groups/validateAccountModal.tsx`
- `libs/query/src/lib/beneficiary/beneficiary.service.ts`
