### PR TITLE
Feedback 2255

### DIFF
--- a/apps/community-tool-ui/src/app/dashboard/layout.tsx
+++ b/apps/community-tool-ui/src/app/dashboard/layout.tsx
@@ -16,11 +16,23 @@ export default function DashboardLayout({
 }: {
   children: React.ReactNode;
 }) {
-
-
   React.useEffect(() => {
-    const handleGroupUpdated = (groupUuid: any) => {
-      toast.success('All beneficiaries have been updated successfully.');
+    const handleGroupUpdated = (message: any) => {
+      const { updatedCount, failedCount } = message;
+      if (updatedCount > 0) {
+        toast.success(
+          `${updatedCount} beneficiar${
+            updatedCount === 1 ? 'y' : 'ies'
+          } updated successfully.`,
+        );
+      }
+      if (failedCount > 0) {
+        toast.error(
+          `${failedCount} beneficiar${
+            failedCount === 1 ? 'y' : 'ies'
+          } failed to update.`,
+        );
+      }
     };
     socket.on('beneficiary-group-updated', handleGroupUpdated);
     return () => {

--- a/apps/community-tool-ui/src/sections/group/groupdetails.tsx
+++ b/apps/community-tool-ui/src/sections/group/groupdetails.tsx
@@ -210,10 +210,6 @@ export default function GroupDetail({ uuid }: IProps) {
       const rdata = listFieldDef?.data?.map((item: any) =>
         simpleString(item.name),
       );
-      // const withUuid = rdata?.includes('uuid')
-      //   ? rdata
-      //   : ['uuid', ...(rdata || [])];
-      // setLabels(withUuid);
       setLabels(rdata);
       return;
     }

--- a/apps/community-tool-ui/src/sections/group/groupdetails.tsx
+++ b/apps/community-tool-ui/src/sections/group/groupdetails.tsx
@@ -210,9 +210,11 @@ export default function GroupDetail({ uuid }: IProps) {
       const rdata = listFieldDef?.data?.map((item: any) =>
         simpleString(item.name),
       );
-
+      // const withUuid = rdata?.includes('uuid')
+      //   ? rdata
+      //   : ['uuid', ...(rdata || [])];
+      // setLabels(withUuid);
       setLabels(rdata);
-
       return;
     }
     const merged = [...labels, simpleString(item)];
@@ -255,6 +257,8 @@ export default function GroupDetail({ uuid }: IProps) {
           filteredItem[dehumanizedString] = '';
         }
       });
+      filteredItem['uuid'] =
+        item['uuid'] ?? item['beneficiary']?.['uuid'] ?? '';
       return filteredItem;
     });
 
@@ -264,7 +268,6 @@ export default function GroupDetail({ uuid }: IProps) {
     XLSX.utils.book_append_sheet(wb, ws, 'Sheet1');
 
     XLSX.writeFile(wb, 'beneficiaries.xlsx');
-    setLabels([]);
   };
 
   const handleVerificationLink = async () => {
@@ -341,19 +344,6 @@ export default function GroupDetail({ uuid }: IProps) {
           },
         );
 
-        // Download the cleaned file for verification
-        const url = URL.createObjectURL(cleanedFile);
-        const a = document.createElement('a');
-        a.href = url;
-        a.download = `cleaned-${selectedFile.name}`;
-        document.body.appendChild(a);
-        a.click();
-        document.body.removeChild(a);
-        URL.revokeObjectURL(url);
-
-        //continue with payload
-        
-
         const formData = new FormData();
         formData.append('file', cleanedFile);
 
@@ -370,11 +360,9 @@ export default function GroupDetail({ uuid }: IProps) {
         });
       }
 
-      setUploadOpen(false);
       setSelectedFile(null);
       router.push('/group');
     } catch (error) {
-      setUploadOpen(false);
       Swal.fire(
         'Upload failed',
         (error as any)?.response?.data?.message || 'Unknown error',
@@ -558,113 +546,8 @@ export default function GroupDetail({ uuid }: IProps) {
                 <AlertDialogFooter>
                   <Button
                     variant="outline"
-                    onClick={() => setLabels([])}
-                    disabled={labels.length === 0}
-                  >
-                    Clear All
-                  </Button>
-                  <AlertDialogAction
-                    onClick={handleDownload}
-                    disabled={labels.length === 0}
-                  >
-                    Download
-                  </AlertDialogAction>
-                </AlertDialogFooter>
-              </AlertDialogContent>
-            </AlertDialog>
-            {/* Upload Dialog */}
-            <AlertDialog open={open} onOpenChange={setOpen}>
-              <AlertDialogContent className="w-full">
-                <AlertDialogHeader>
-                  <AlertDialogTitle>
-                    <div className="flex justify-between items-center pb-1 gap-4">
-                      <TooltipProvider delayDuration={100}>
-                        <Tooltip>
-                          <TooltipTrigger>
-                            <Label className="text-lg font-medium">
-                              Select fields to download
-                            </Label>
-                          </TooltipTrigger>
-                        </Tooltip>
-                      </TooltipProvider>
-                      <TooltipProvider delayDuration={100}>
-                        <Tooltip>
-                          <TooltipTrigger onClick={() => setOpen(false)}>
-                            <X
-                              className="text-muted-foreground hover:text-foreground text-red-700"
-                              size={23}
-                              strokeWidth={1.9}
-                            />
-                          </TooltipTrigger>
-                          <TooltipContent>
-                            <p>Close</p>
-                          </TooltipContent>
-                        </Tooltip>
-                      </TooltipProvider>
-                    </div>
-                  </AlertDialogTitle>
-                  <AlertDialogDescription>
-                    <ScrollArea
-                      className={`${
-                        labels.length < 10 ? 'h-32' : 'h-52'
-                      } w-[95%] border m-2 pt-1 pb-1 text-sm rounded-md shadow-lg cursor-pointer bg-white`}
-                      hidden={labels.length === 0}
-                    >
-                      {labels.map((item) => {
-                        return (
-                          <Badge key={item} variant="secondary" className="m-1">
-                            {item}
-                            <button
-                              className="ml-1 ring-offset-background rounded-full outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
-                              onKeyDown={(e) => {
-                                if (e.key === 'Enter') {
-                                  handleUnselect(item);
-                                }
-                              }}
-                              onMouseDown={(e) => {
-                                e.preventDefault();
-                                e.stopPropagation();
-                              }}
-                              onClick={() => handleUnselect(item)}
-                            >
-                              <X className="h-3 w-3 text-muted-foreground hover:text-foreground" />
-                            </button>
-                          </Badge>
-                        );
-                      })}
-
-                      {labels.length === 0 && (
-                        <h1 className="text-center ">No fields selected</h1>
-                      )}
-                    </ScrollArea>
-
-                    <Command className="h-52">
-                      <CommandInput
-                        placeholder={'Search field...'}
-                        autoFocus={true}
-                      />
-                      <CommandList className="no-scrollbar">
-                        <CommandEmpty>No field found.</CommandEmpty>
-                        <CommandGroup>
-                          {sortedSelectables?.map((item) => (
-                            <CommandItem
-                              key={item.uuid}
-                              value={item.name}
-                              onSelect={() => handleSelectChange(item.name)}
-                            >
-                              {simpleString(item.name)}
-                            </CommandItem>
-                          ))}
-                        </CommandGroup>
-                      </CommandList>
-                    </Command>
-                  </AlertDialogDescription>
-                </AlertDialogHeader>
-                <AlertDialogFooter>
-                  <Button
-                    variant="outline"
-                    onClick={() => setLabels([])}
-                    disabled={labels.length === 0}
+                    onClick={() => setLabels(['uuid'])}
+                    disabled={labels.length <= 1}
                   >
                     Clear All
                   </Button>
@@ -705,6 +588,7 @@ export default function GroupDetail({ uuid }: IProps) {
                   </Button>
                   <Button
                     onClick={async () => {
+                      setUploadOpen(false);
                       await handleUpload();
                     }}
                   >


### PR DESCRIPTION
## 🔗 Related Issue

[issue](https://github.com/rahataid/rahat-beneficiary-mgmt/issues/522#issue-4749574674)

- [ ] Added issue link

## 📌 Description

<!-- What does this PR do? Explain clearly -->

This PR addresses the following feedback items:

- Default selection of UUID field when user chooses to download group beneficiaries.
- Display the number of successfully updated beneficiaries in the toast message after a bulk update operation.
- Clear dialog content after clicking "OK" when attempting to upload without selecting a file.

---

## ✅ Checklist

- [x] No `console.log` or debug code left
- [x] Proper error handling implemented
- [x] Loading states handled (if needed)
- [x] API calls handled safely
- [x] No unnecessary code or comments
- [x] Self-reviewed code for logic, edge cases, and potential issues

---

## 🎯 Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] UI update
- [ ] Refactor
- [ ] Performance improvement

---

## changes Made

- Added logic to pre-select UUID as the default field in the group beneficiaries download flow.
- Enhanced bulk update success toast to include the count of updated beneficiaries (e.g., "X beneficiaries updated successfully").
- Fixed upload dialog state management so content is properly cleared/reset after confirmation when no file is selected.

---

## ⚠️ Notes for Reviewer

<!-- Anything special reviewer should know -->

-
