### PR TITLE
Update samples

### DIFF
--- a/apps/community-tool-ui/src/sections/field-definitions/listView.tsx
+++ b/apps/community-tool-ui/src/sections/field-definitions/listView.tsx
@@ -24,6 +24,7 @@ import { ScrollArea } from '@rahat-ui/shadcn/src/components/ui/scroll-area';
 import { FieldDefinition } from '@rahataid/community-tool-sdk/fieldDefinitions';
 import { Label } from '@rahat-ui/shadcn/src/components/ui/label';
 import React from 'react';
+import { toast } from 'react-toastify';
 import {
   useCommunitySettingList,
   useCommunitySettingUpdate,
@@ -71,6 +72,7 @@ export default function ListView({
   const aiSetting = data?.data.find(
     (setting: { name: string }) => setting.name === 'AI_API_URL',
   );
+  console.log(aiSetting, 'aiSetting');
 
   const aiBaseurl = aiSetting?.value?.URL;
   const aiStandardName = aiSetting?.value?.COMMUNITY_DATA_STANDARD;
@@ -187,9 +189,6 @@ export default function ListView({
 
     try {
       if (aiStandardName) {
-        console.log(
-          'Checking existing standard fields against current field definitions...',
-        );
         const existingJson = await getStandardFields.mutateAsync({
           standardName: aiStandardName,
           baseURL: aiBaseurl,
@@ -210,10 +209,7 @@ export default function ListView({
         return;
       }
 
-      const standardName = 'community_data_standard';
-      await uploadSchemaFile(standardName);
-      await updateStandardSetting(standardName);
-      setSyncStatus('synced');
+      toast.warn('Please add a standard name in settings before syncing.');
     } catch (error) {
       console.error('Sync failed:', error);
       setSyncStatus('not-synced');

--- a/apps/community-tool-ui/src/sections/settings/data.tsx
+++ b/apps/community-tool-ui/src/sections/settings/data.tsx
@@ -43,9 +43,13 @@ export const SETTINGS_SAMPLE: Setting[] = [
     name: 'VERIFICATION_APP',
     description:
       'This settings is used to verify beneficiary wallet. Enter the URL of the verification app as follows:',
-
     requiredFields: 'URL',
-    key_value: [{ key: 'URL', value: '{YOUR_API_URL}/verify' }],
+    key_value: [
+      {
+        key: 'URL',
+        value: '{YOUR_API_URL}/verify',
+      },
+    ],
   },
   {
     name: 'COMMUNICATIONS',
@@ -60,6 +64,34 @@ export const SETTINGS_SAMPLE: Setting[] = [
       {
         key: 'APP_ID',
         value: '{COMM_APP_ID}',
+      },
+    ],
+  },
+  {
+    name: 'VALIDATE_SECONDARY_FIELD',
+    requiredFields: 'DATA',
+    description:
+      'This setting controls whether secondary fields should be validated during beneficiary import or update. Set the value to true to enable validation or false to disable it.',
+    key_value: [
+      {
+        key: 'DATA',
+        value: 'true',
+      },
+    ],
+  },
+  {
+    name: 'AI_API_URL',
+    requiredFields: 'URL, COMMUNITY_DATA_STANDARD',
+    description:
+      'This setting is used to configure the AI service endpoint for field mapping and define the community data standard used to generate field suggestions.. The COMMUNITY_DATA_STANDARD value should be specific to each project.',
+    key_value: [
+      {
+        key: 'URL',
+        value: '{AI_API_URL}',
+      },
+      {
+        key: 'COMMUNITY_DATA_STANDARD',
+        value: '{PROJECT_COMMUNITY_DATA_STANDARD}',
       },
     ],
   },


### PR DESCRIPTION
## 🔗 Related Issue

<!-- Link issue (if any) -->

[issue](https://github.com/rahataid/rahat-ui/issues/2395)
## 📌 Description

This PR updates the sample project settings by adding configuration examples for AI-assisted field mapping and secondary field validation. It also improves the field sync flow by validating the required AI configuration before allowing users to sync fields.


---

## Changes

### Added `VALIDATE_SECONDARY_FIELD`

Introduced a new sample setting to control whether secondary fields should be validated during beneficiary import and update.

- **Required Field:** `DATA`
- **Supported Values:** `true` or `false`

Example:

```json
{
  "name": "VALIDATE_SECONDARY_FIELD",
  "requiredFields": "DATA",
  "key_value": [
    {
      "key": "DATA",
      "value": "true"
    }
  ]
}
```

### Added `AI_API_URL`

Introduced a new sample setting for configuring the AI service used for field mapping and field name suggestions.

This setting requires the following keys:

- `URL` – AI service endpoint
- `COMMUNITY_DATA_STANDARD` – Project-specific community data standard used by the AI to generate field mapping suggestions

Both keys are required.

Example:

```json
{
  "name": "AI_API_URL",
  "requiredFields": "URL, COMMUNITY_DATA_STANDARD",
  "key_value": [
    {
      "key": "URL",
      "value": "{AI_API_URL}"
    },
    {
      "key": "COMMUNITY_DATA_STANDARD",
      "value": "{PROJECT_COMMUNITY_DATA_STANDARD}"
    }
  ]
}
```

### Added validation before field sync

Before allowing users to sync fields, the application now validates that the `COMMUNITY_DATA_STANDARD` has been configured in the project settings.

- If the setting is missing or empty, the sync request is not initiated.
- A toast notification is displayed to the user:
  > **Please add the Community Data Standard in Settings before syncing fields.**

---


## ✅ Checklist

- [x] No `console.log` or debug code left
- [x] Proper error handling implemented
- [x] Loading states handled (if needed)
- [x] API calls handled safely
- [x] No unnecessary code or comments
- [x] Self-reviewed code for logic, edge cases, and potential issues

---

## 📸 changes in  samples setting 

### 1. For Ai Setting 

<img width="1470" height="956" alt="AI_API_URL" src="https://github.com/user-attachments/assets/0a76e811-f467-4aa9-8bfc-6a93c5169252" />



### 2. For secondary Field

<img width="1470" height="956" alt="secondary-field" src="https://github.com/user-attachments/assets/bcb14345-b080-4c40-bb96-e6b3a02ca048" />


---

## 🧪 How to Test

<!-- Steps to test this PR -->

1. Go to the Field List in Settings and click Sync System Fields with AI. If the Community Data Standard is not configured in Settings, a toast message will be displayed.
<img width="1470" height="956" alt="toast message for setting" src="https://github.com/user-attachments/assets/d9ebbb79-beb8-4e8c-8530-6ee898647c9d" />


3. Go to Settings and add the Community Data Standard, as shown in Image 1

<img width="1470" height="956" alt="added-value-setting" src="https://github.com/user-attachments/assets/baef3c4e-1c51-4139-9eb2-ee23a8831009" />


## ⚠️ Notes for Reviewer

<!-- Anything special reviewer should know -->

-
