### PR TITLE
2379 dashboard metrics show na and 0 during data reload on fund management details page

### DIFF
--- a/apps/rahat-ui/src/common/table.tsx
+++ b/apps/rahat-ui/src/common/table.tsx
@@ -9,7 +9,7 @@ import {
   TableHeader,
   TableRow,
 } from '@rahat-ui/shadcn/src/components/ui/table';
-import { SpinnerLoader } from './spinner.loader';
+import { Skeleton } from '@rahat-ui/shadcn/src/components/ui/skeleton';
 
 type IProps = {
   table: Table<any>;
@@ -32,19 +32,26 @@ export function DemoTable({
   height = '340px',
   fixedLayout = true,
 }: IProps) {
-  const hasRows = table.getRowModel().rows?.length > 0;
+  const hasRows = table.getRowModel().rows.length > 0;
   const containerClass = tableHeight ?? `h-[max(280px,calc(100vh-${height}))]`;
+
+  const visibleColumns = table.getVisibleLeafColumns();
 
   return (
     <div className={`overflow-auto ${containerClass}`}>
-      <TableComponent className={`w-full ${fixedLayout ? 'table-fixed' : 'table-auto'}`}>
+      <TableComponent
+        className={`w-full ${fixedLayout ? 'table-fixed' : 'table-auto'}`}
+      >
         <TableHeader className="sticky top-0 z-10 border-b [&_th]:bg-muted">
           {table.getHeaderGroups().map((headerGroup) => (
             <TableRow key={headerGroup.id}>
               {headerGroup.headers.map((header) => (
                 <TableHead
                   key={header.id}
-                  className={(header.column.columnDef.meta as ColumnMeta | undefined)?.className}
+                  className={
+                    (header.column.columnDef.meta as ColumnMeta | undefined)
+                      ?.className
+                  }
                 >
                   {header.isPlaceholder
                     ? null
@@ -57,16 +64,24 @@ export function DemoTable({
             </TableRow>
           ))}
         </TableHeader>
+
         <TableBody>
           {loading ? (
-            <TableRow>
-              <TableCell
-                colSpan={table.getAllColumns().length}
-                className="h-24 text-center"
-              >
-                <SpinnerLoader />
-              </TableCell>
-            </TableRow>
+            Array.from({ length: 8 }).map((_, rowIndex) => (
+              <TableRow key={rowIndex}>
+                {visibleColumns.map((column) => (
+                  <TableCell
+                    key={column.id}
+                    className={
+                      (column.columnDef.meta as ColumnMeta | undefined)
+                        ?.className
+                    }
+                  >
+                    <Skeleton className="h-4 w-full rounded" />
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))
           ) : hasRows ? (
             table.getRowModel().rows.map((row) => (
               <TableRow
@@ -76,7 +91,10 @@ export function DemoTable({
                 {row.getVisibleCells().map((cell) => (
                   <TableCell
                     key={cell.id}
-                    className={(cell.column.columnDef.meta as ColumnMeta | undefined)?.className}
+                    className={
+                      (cell.column.columnDef.meta as ColumnMeta | undefined)
+                        ?.className
+                    }
                   >
                     {flexRender(cell.column.columnDef.cell, cell.getContext())}
                   </TableCell>
@@ -86,7 +104,7 @@ export function DemoTable({
           ) : (
             <TableRow>
               <TableCell
-                colSpan={table.getAllColumns().length}
+                colSpan={visibleColumns.length}
                 className="h-24 text-center"
               >
                 <NoResult message={message} />

--- a/apps/rahat-ui/src/common/table.tsx
+++ b/apps/rahat-ui/src/common/table.tsx
@@ -67,7 +67,7 @@ export function DemoTable({
 
         <TableBody>
           {loading ? (
-            Array.from({ length: 8 }).map((_, rowIndex) => (
+            Array.from({ length: 5 }).map((_, rowIndex) => (
               <TableRow key={rowIndex}>
                 {visibleColumns.map((column) => (
                   <TableCell

--- a/apps/rahat-ui/src/sections/projects/aa-2/fundManagement/details.tsx
+++ b/apps/rahat-ui/src/sections/projects/aa-2/fundManagement/details.tsx
@@ -6,6 +6,11 @@ import { UUID } from 'crypto';
 import { DataCard, HeaderWithBack } from 'apps/rahat-ui/src/common';
 import { ONE_TOKEN_VALUE } from 'apps/rahat-ui/src/constants/aa.constants';
 import { Skeleton } from '@rahat-ui/shadcn/src/components/ui/skeleton';
+import {
+  Card,
+  CardContent,
+  CardHeader,
+} from '@rahat-ui/shadcn/src/components/ui/card';
 
 export default function FundManagementDetail() {
   const { id: projectID, fundId } = useParams();
@@ -82,15 +87,15 @@ export default function FundManagementDetail() {
 
 function DataCardSkeleton() {
   return (
-    <div className="rounded-lg border flex flex-col">
-      <div className="p-4 pb-2 space-y-2">
+    <Card className="flex flex-col rounded-lg border justify-center">
+      <CardHeader className="pb-2 p-4">
         <Skeleton className="h-4 w-28" />
-        <Skeleton className="h-4 w-20" />
-      </div>
+        <Skeleton className="mt-2 h-4 w-20" />
+      </CardHeader>
 
-      <div className="px-6 pb-6">
+      <CardContent>
         <Skeleton className="h-8 w-24" />
-      </div>
-    </div>
+      </CardContent>
+    </Card>
   );
 }

--- a/apps/rahat-ui/src/sections/projects/aa-2/fundManagement/details.tsx
+++ b/apps/rahat-ui/src/sections/projects/aa-2/fundManagement/details.tsx
@@ -5,25 +5,7 @@ import { useSingleGroupReservedFunds } from '@rahat-ui/query';
 import { UUID } from 'crypto';
 import { DataCard, HeaderWithBack } from 'apps/rahat-ui/src/common';
 import { ONE_TOKEN_VALUE } from 'apps/rahat-ui/src/constants/aa.constants';
-
-// export const FMTokensData = [
-//   {
-//     name: 'Tokens',
-//     amount: '1000',
-//   },
-//   {
-//     name: 'Total Beneficiaries',
-//     amount: '10',
-//   },
-//   {
-//     name: 'Created By',
-//     amount: 'John Doe',
-//   },
-//   {
-//     name: '1 Token Value',
-//     amount: 'Rs. 10',
-//   },
-// ];
+import { Skeleton } from '@rahat-ui/shadcn/src/components/ui/skeleton';
 
 export default function FundManagementDetail() {
   const { id: projectID, fundId } = useParams();
@@ -32,14 +14,15 @@ export default function FundManagementDetail() {
     projectID as UUID,
     fundId,
   );
+
   const FMTokensData = [
     {
       name: 'Tokens',
-      amount: data?.numberOfTokens || 'N/A',
+      amount: data?.numberOfTokens ?? 'N/A',
     },
     {
       name: 'Total Beneficiaries',
-      amount: data?.groupedBeneficiaries?.length || 0,
+      amount: data?.groupedBeneficiaries?.length ?? 0,
     },
     {
       name: 'Created By',
@@ -56,38 +39,58 @@ export default function FundManagementDetail() {
       <div className="flex justify-between items-center">
         <HeaderWithBack
           path={`/projects/aa/${projectID}/fund-management?tab=fundManagementList`}
-          title={data?.title}
-          subtitle={`Detailed view of reserved fund`}
-          status={data?.status.replace(/_/g, ' ')}
+          title={isLoading ? <Skeleton className="h-7 w-56" /> : data?.title}
+          subtitle="Detailed view of reserved fund"
+          status={isLoading ? undefined : data?.status?.replace(/_/g, ' ')}
           badgeClassName={
             data?.status === 'DISBURSED'
               ? 'bg-green-100 text-green-500'
               : data?.status === 'STARTED'
               ? 'bg-blue-100 text-blue-500'
-              : ['FAILED', 'ERROR'].includes(data?.status)
+              : ['FAILED', 'ERROR'].includes(data?.status ?? '')
               ? 'bg-red-100 text-red-500'
               : 'bg-gray-200'
           }
         />
       </div>
+
       <div className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-4 gap-4 mb-4">
-        {/* <div className="flex gap-6 mb-3"> */}
-        {FMTokensData?.map((i) => (
-          <DataCard
-            key={i.name}
-            title={i.name}
-            number={i.amount}
-            className="border-solid  rounded-md"
-            iconStyle="bg-white text-secondary-muted"
-          />
-        ))}
+        {isLoading
+          ? Array.from({ length: 4 }).map((_, index) => (
+              <DataCardSkeleton key={index} />
+            ))
+          : FMTokensData.map((item) => (
+              <DataCard
+                key={item.name}
+                title={item.name}
+                number={item.amount}
+                className="border-solid rounded-md"
+                iconStyle="bg-white text-secondary-muted"
+              />
+            ))}
       </div>
+
       <FundManagementDetailTable
         title={data?.name}
         group={data?.groupedBeneficiaries}
         loading={isLoading}
         status={data?.status}
       />
+    </div>
+  );
+}
+
+function DataCardSkeleton() {
+  return (
+    <div className="rounded-lg border flex flex-col">
+      <div className="p-4 pb-2 space-y-2">
+        <Skeleton className="h-4 w-28" />
+        <Skeleton className="h-4 w-20" />
+      </div>
+
+      <div className="px-6 pb-6">
+        <Skeleton className="h-8 w-24" />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## 🔗 Related Issue

https://github.com/rahataid/rahat-ui/issues/2379

- [x] Added issue link

## 📌 Description

<!-- What does this PR do? Explain clearly -->

- Added skeleton loading states to the Fund Management Detail page.
- Displayed skeleton placeholders for the page header, summary cards, and beneficiary table while data is being fetched.

---

## ✅ Checklist

- [x] No `console.log` or debug code left
- [ ] Proper error handling implemented
- [ ] Loading states handled (if needed)
- [ ] API calls handled safely
- [x] No unnecessary code or comments
- [x] Self-reviewed code for logic, edge cases, and potential issues

---

## 🎯 Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] UI update
- [ ] Refactor
- [ ] Performance improvement

---

## 📸 Before / After

### Before

<img width="1734" height="1097" alt="image" src="https://github.com/user-attachments/assets/1f447c0b-4bf8-4efa-b14f-e4477df7ef58" />

### After

<img width="1710" height="1069" alt="image" src="https://github.com/user-attachments/assets/ed910f3f-5386-4c19-b280-b08cbe166a88" />

---

## 🧪 How to Test

<!-- Steps to test this PR -->

1. Navigate to Fund Management.
2. Open a reserved fund detail page.
3. Refresh the page or throttle the network to observe the loading state.
4. Verify that skeletons are displayed for the header, summary cards, and beneficiary table until the data loads.

---

## ⚠️ Notes for Reviewer

<!-- Anything special reviewer should know -->

- Replaced loading indicators with skeleton placeholders on the Fund Management Detail page for a more consistent loading experience.
