### PR TITLE
allow user to import into exiting group

### DIFF
--- a/apps/community-tool-ui/src/sections/beneficiary/import/AddToQueue.tsx
+++ b/apps/community-tool-ui/src/sections/beneficiary/import/AddToQueue.tsx
@@ -1,4 +1,28 @@
+import { useCommunityGroupList } from '@rahat-ui/community-query';
+import { usePagination } from '@rahat-ui/query';
+import { cn } from '@rahat-ui/shadcn/src';
 import { Button } from '@rahat-ui/shadcn/src/components/ui/button';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@rahat-ui/shadcn/src/components/ui/command';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@rahat-ui/shadcn/src/components/ui/dialog';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@rahat-ui/shadcn/src/components/ui/popover';
 import {
   Tooltip,
   TooltipContent,
@@ -9,12 +33,19 @@ import {
   humanizeString,
   truncatedText,
 } from 'apps/community-tool-ui/src/utils';
-import { ArrowBigLeft, ArrowBigUp, CloudDownloadIcon } from 'lucide-react';
+import {
+  ArrowBigLeft,
+  ArrowBigUp,
+  Check,
+  ChevronsUpDown,
+  CloudDownloadIcon,
+} from 'lucide-react';
+import { useState } from 'react';
 
 interface IProps {
   data: any;
   handleRetargetClick: any;
-  handleImportClick: any;
+  handleImportWithGroup: (groupName: string | null) => void;
   invalidFields: any;
   handleExportInvalidClick: any;
   hasUUID: boolean;
@@ -24,18 +55,31 @@ interface IProps {
 export default function AddToQueue({
   data,
   handleRetargetClick,
-  handleImportClick,
+  handleImportWithGroup,
   invalidFields,
   handleExportInvalidClick,
   hasUUID,
   loading,
 }: IProps) {
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [useExistingGroup, setUseExistingGroup] = useState(false);
+  const [selectGroupName, setSelectedGroupName] = useState<string | null>(null);
+  const [groupPopoverOpen, setGroupPopoverOpen] = useState(false);
+
+  const { pagination, filters } = usePagination();
+  pagination.perPage = 50;
+  pagination.page = 1;
+  const { data: groupData } = useCommunityGroupList({
+    ...pagination,
+    ...filters,
+  });
+
   const mappedData =
     data.length > 0
       ? data.map((d: any) => {
-        const { rawData, ...rest } = d;
-        return rest;
-      })
+          const { rawData, ...rest } = d;
+          return rest;
+        })
       : [];
 
   const headerKeys = mappedData.length > 0 ? Object.keys(mappedData[0]) : [];
@@ -45,10 +89,8 @@ export default function AddToQueue({
       return '';
     }
 
-    // Handle boolean values
     if (typeof item[key] === 'boolean') {
       return item[key] ? 'Yes' : 'No';
-      // OR return item[key].toString();
     }
 
     return item[key];
@@ -58,13 +100,26 @@ export default function AddToQueue({
 
   const enableDisableImportButton = () => {
     if (hasUUID) return false;
-
     if (invalidFields.length || hasDuplicates) return true;
-
     if (loading) return true;
-
     return false;
   };
+
+  const handleOpenDialog = () => {
+    setUseExistingGroup(false);
+    setSelectedGroupName(null);
+    setDialogOpen(true);
+  };
+
+  const handleDialogImport = () => {
+    setDialogOpen(false);
+    handleImportWithGroup(useExistingGroup ? selectGroupName : null);
+  };
+  const isImportNowDisabled = useExistingGroup && !selectGroupName;
+
+  const selectedGroupName = selectGroupName
+    ? groupData?.data?.rows?.find((g: any) => g.name === selectGroupName)?.name
+    : null;
 
   return (
     <div className="relative mt-5">
@@ -87,7 +142,7 @@ export default function AddToQueue({
 
           <Button
             disabled={enableDisableImportButton()}
-            onClick={handleImportClick}
+            onClick={handleOpenDialog}
             className="w-40 bg-primary hover:ring-2 ring-primary py-2 px-4"
           >
             <CloudDownloadIcon size={18} strokeWidth={2} />
@@ -96,6 +151,129 @@ export default function AddToQueue({
         </div>
       </div>
 
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogContent className="sm:max-w-[480px]">
+          <DialogHeader>
+            <DialogTitle>Import Beneficiaries</DialogTitle>
+            <DialogDescription>
+              Where do you want to import these beneficiaries?
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4 py-2">
+            <div
+              className={cn(
+                'flex items-start gap-3 rounded-lg border p-4 cursor-pointer transition-colors',
+                useExistingGroup
+                  ? 'border-primary bg-primary/5'
+                  : 'border-gray-200',
+              )}
+              onClick={() => setUseExistingGroup(true)}
+            >
+              <div
+                className={cn(
+                  'mt-0.5 h-4 w-4 rounded-full border-2 flex-shrink-0',
+                  useExistingGroup
+                    ? 'border-primary bg-primary'
+                    : 'border-gray-400',
+                )}
+              />
+              <div className="flex-1 space-y-2">
+                <p className="font-medium text-sm">
+                  Import into an existing group
+                </p>
+                {useExistingGroup && (
+                  <Popover
+                    open={groupPopoverOpen}
+                    onOpenChange={setGroupPopoverOpen}
+                  >
+                    <PopoverTrigger asChild>
+                      <Button
+                        variant="secondary"
+                        role="combobox"
+                        className="w-full justify-between font-normal text-muted-foreground hover:text-muted-foreground bg-white hover:bg-white border"
+                        onClick={(e) => e.stopPropagation()}
+                      >
+                        {selectedGroupName ?? 'Select group'}
+                        <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                      </Button>
+                    </PopoverTrigger>
+                    <PopoverContent className="w-full p-0 h-[200px]">
+                      <Command>
+                        <CommandInput placeholder="Search group..." />
+                        <CommandList>
+                          <CommandEmpty>No group found.</CommandEmpty>
+                          <CommandGroup>
+                            {groupData?.data?.rows?.map((item: any) => (
+                              <CommandItem
+                                key={item.uuid}
+                                value={item.name}
+                                onSelect={() => {
+                                  setSelectedGroupName(item.name);
+                                  setGroupPopoverOpen(false);
+                                }}
+                              >
+                                <Check
+                                  className={cn(
+                                    'mr-2 h-4 w-4',
+                                    item.name === selectGroupName
+                                      ? 'opacity-100'
+                                      : 'opacity-0',
+                                  )}
+                                />
+                                {item.name}
+                              </CommandItem>
+                            ))}
+                          </CommandGroup>
+                        </CommandList>
+                      </Command>
+                    </PopoverContent>
+                  </Popover>
+                )}
+              </div>
+            </div>
+
+            <div
+              className={cn(
+                'flex items-start gap-3 rounded-lg border p-4 cursor-pointer transition-colors',
+                !useExistingGroup
+                  ? 'border-primary bg-primary/5'
+                  : 'border-gray-200',
+              )}
+              onClick={() => setUseExistingGroup(false)}
+            >
+              <div
+                className={cn(
+                  'mt-0.5 h-4 w-4 rounded-full border-2 flex-shrink-0',
+                  !useExistingGroup
+                    ? 'border-primary bg-primary'
+                    : 'border-gray-400',
+                )}
+              />
+              <div>
+                <p className="font-medium text-sm">Proceed without a group</p>
+                <p className="text-xs text-muted-foreground mt-0.5">
+                  A group will be auto-created by the system
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setDialogOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              disabled={isImportNowDisabled}
+              onClick={handleDialogImport}
+              className="bg-primary hover:ring-2 ring-primary"
+            >
+              Import Now
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
       <hr />
 
       <div className="table-wrp block h-screen import-container overflow-x-auto">
@@ -103,11 +281,7 @@ export default function AddToQueue({
           <thead className="bg-white border-b sticky top-0">
             <tr>
               {headerKeys.map((key) => (
-                <th
-                  style={{ minWidth: 150 }}
-                  className="px-2 py-1"
-                  key={key}
-                >
+                <th style={{ minWidth: 150 }} className="px-2 py-1" key={key}>
                   {invalidFields.find(
                     (field: any) => field.fieldName === key,
                   ) ? (
@@ -128,10 +302,11 @@ export default function AddToQueue({
             {data.map((item: any, index: number) => (
               <tr
                 key={index}
-                className={`${item.isDuplicate
-                  ? 'bg-orange-100 border-b'
-                  : 'odd:bg-white odd:dark:bg-gray-900 even:bg-gray-50 even:dark:bg-gray-800 border-b dark:border-gray-700'
-                  }`}
+                className={`${
+                  item.isDuplicate
+                    ? 'bg-orange-100 border-b'
+                    : 'odd:bg-white odd:dark:bg-gray-900 even:bg-gray-50 even:dark:bg-gray-800 border-b dark:border-gray-700'
+                }`}
               >
                 {headerKeys.map((key) => {
                   const errorData = invalidFields.find(
@@ -148,10 +323,7 @@ export default function AddToQueue({
                   // DUPLICATE + INVALID
                   if (item.isDuplicate && isInvalid) {
                     return (
-                      <td
-                        className="px-4 py-1.5 bg-red-100"
-                        key={key}
-                      >
+                      <td className="px-4 py-1.5 bg-red-100" key={key}>
                         <TooltipProvider>
                           <Tooltip>
                             <TooltipTrigger asChild>
@@ -175,10 +347,7 @@ export default function AddToQueue({
                   // INVALID STATUS
                   if (isInvalid) {
                     return (
-                      <td
-                        className="px-4 py-1.5 bg-red-100"
-                        key={key}
-                      >
+                      <td className="px-4 py-1.5 bg-red-100" key={key}>
                         <TooltipProvider>
                           <Tooltip>
                             <TooltipTrigger asChild>
@@ -199,10 +368,7 @@ export default function AddToQueue({
                   // DUPLICATE ROW
                   if (item.isDuplicate) {
                     return (
-                      <td
-                        className="px-4 py-1.5"
-                        key={key}
-                      >
+                      <td className="px-4 py-1.5" key={key}>
                         <TooltipProvider>
                           <Tooltip>
                             <TooltipTrigger asChild>
@@ -222,10 +388,7 @@ export default function AddToQueue({
 
                   // NORMAL CELL
                   return (
-                    <td
-                      className="px-4 py-1.5"
-                      key={key}
-                    >
+                    <td className="px-4 py-1.5" key={key}>
                       {cellContent}
                     </td>
                   );

--- a/apps/community-tool-ui/src/sections/beneficiary/import/Beneficiary.tsx
+++ b/apps/community-tool-ui/src/sections/beneficiary/import/Beneficiary.tsx
@@ -254,7 +254,6 @@ export default function BenImp({ fieldDefinitions }: IProps) {
     sourceField: string,
     targetField: string,
   ) => {
-
     // Source field as it is
     // Target field sanitized
     if (sourceField === EMPTY_SELECTION) {
@@ -342,32 +341,23 @@ export default function BenImp({ fieldDefinitions }: IProps) {
     return setCurrentScreen(BENEF_IMPORT_SCREENS.VALIDATION);
   };
 
-  const handleImportNowClick = async () => {
-    const msg = hasUUID
-      ? 'Duplicate data will be replaced! <b>Import Anyway?</b>'
-      : '';
-    const dialog = await Swal.fire({
-      icon: 'info',
-      title: `${processedData.length} Beneficiaries will be imported!`,
-      text: msg,
-      showCancelButton: true,
-      confirmButtonText: 'Import Now',
-      cancelButtonText: 'No',
-      html: msg,
-    });
-    if (dialog.isConfirmed) {
-      if (!validBenef.length) return validateOrImport(IMPORT_ACTION.IMPORT);
-      const sourcePayload = {
-        action: IMPORT_ACTION.IMPORT,
-        name: importSource,
-        importId,
-        fieldMapping: { data: validBenef, sourceTargetMappings: mappings },
-      };
-      return createImportSource(sourcePayload);
-    }
+  const handleImportNowClick = async (groupName: string | null) => {
+    if (!validBenef.length)
+      return validateOrImport(IMPORT_ACTION.IMPORT, groupName);
+    const sourcePayload = {
+      action: IMPORT_ACTION.IMPORT,
+      name: importSource,
+      importId,
+      groupName,
+      fieldMapping: { data: validBenef, sourceTargetMappings: mappings },
+    };
+    return createImportSource(sourcePayload);
   };
 
-  const validateOrImport = (action: string) => {
+  const validateOrImport = (
+    action: string,
+    groupName: string | null = null,
+  ) => {
     setValidBenef([]);
 
     const finalMappings = [...mappings];
@@ -439,13 +429,19 @@ export default function BenImp({ fieldDefinitions }: IProps) {
         finalPayload = replaced;
       }
     }
-    return validateAndImortBeneficiary(finalPayload, selectedTargets, action);
+    return validateAndImortBeneficiary(
+      finalPayload,
+      selectedTargets,
+      action,
+      groupName,
+    );
   };
 
   const validateAndImortBeneficiary = (
     finalPayload: any,
     selectedTargets: any,
     action: string,
+    groupName: string | null = null,
   ) => {
     if (!selectedTargets.length)
       return Swal.fire({
@@ -461,6 +457,7 @@ export default function BenImp({ fieldDefinitions }: IProps) {
       action,
       name: importSource,
       importId,
+      groupName,
       fieldMapping: { data: final_mapping, sourceTargetMappings: mappings },
     };
 
@@ -633,7 +630,7 @@ export default function BenImp({ fieldDefinitions }: IProps) {
               handleExportInvalidClick={handleExportInvalidClick}
               handleRetargetClick={handleRetargetClick}
               data={processedData}
-              handleImportClick={handleImportNowClick}
+              handleImportWithGroup={handleImportNowClick}
               invalidFields={invalidFields}
               loading={loading}
             />


### PR DESCRIPTION
## 🔗 Related Issue

<!-- Link issue (if any) -->

- [ issue](https://github.com/rahataid/rahat-ui/issues/2402) Added issue link

## 📌 Description

<!-- What does this PR do? Explain clearly -->

Previously, clicking **Import Valid** during beneficiary import immediately triggered the import, and the backend automatically created a new group for the imported beneficiaries.

This PR introduces a group selection step before importing beneficiaries, allowing users to choose how the import should be handled.
---

## Changes
- Added a group selection dialog that opens when **Import Valid** is clicked.
- Users can now choose one of the following options:
  - **Import into an existing group**
    - Displays a searchable list of existing non-auto-created groups.
    - The **Import Now** button remains disabled until a group is selected.
  - **Proceed without a group**
    - Preserves the existing behavior where the backend automatically creates a new group.
- Passed the selected `groupName` through the import flow so the backend can import beneficiaries directly into the selected group.
- Removed the previous confirmation dialog since the new group selection dialog now handles the import confirmation.


## ✅ Checklist

- [x] No `console.log` or debug code left
- [x] Proper error handling implemented
- [x] Loading states handled (if needed)
- [x] API calls handled safely
- [x] No unnecessary code or comments
- [x] Self-reviewed code for logic, edge cases, and potential issues

---

## 🎯 Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] UI update
- [ ] Refactor
- [ ] Performance improvement

---

## 📸 Before / After

### Before

<img width="1470" height="956" alt="before-import" src="https://github.com/user-attachments/assets/918ccac9-6b4f-4ebe-b099-fcd150b58f87" />

#### Clicking **Import Valid**  immediately triggered the import, and  the backend automatically created a new group
<img width="1470" height="956" alt="import-second" src="https://github.com/user-attachments/assets/1d21af74-c180-450d-a967-d791dc0f0959" />



### After

#### Clicking **Import Valid** open the group selection dialog
<img width="1470" height="956" alt="dialog content" src="https://github.com/user-attachments/assets/16451484-1457-458c-99a2-a7fa3ca5fb41" />

#### list of Existing Group 

<img width="1470" height="956" alt="existing-group-list" src="https://github.com/user-attachments/assets/95d615d7-2f15-482c-b965-25eb6a442b31" />


---

## 🧪 How to Test

<!-- Steps to test this PR -->

1. Upload a valid beneficiary file.
2. Map the fields and click **Validate**.
3. On the import summary screen, click **Import Valid**.
4. Verify that the group selection dialog is displayed.
5. Select **Import into an existing group**.
6. Search for and select an existing non-auto-created group.
7. Verify that the **Import Now** button is disabled until a group is selected.
8. Click **Import Now** and verify:
   - The import completes successfully.
   - Beneficiaries are imported into the selected group.
9. Repeat the import and select **Proceed without a group**.
10. Click **Import Now** and verify:
    - The import completes successfully.
    - A new group is automatically created by the backend (existing behavior).
11. Click **Cancel** and verify that the dialog closes without triggering an import.
---

## ⚠️ Notes for Reviewer

<!-- Anything special reviewer should know -->

- This PR depends on the corresponding backend PR. Please deploy/run the backend PR before testing this frontend change  [backend-pr](https://github.com/rahataid/rahat-beneficiary-mgmt/pull/527)
