### PR TITLE
fix: replaced createdat to updated at in comm logs table timestamp

### DIFF
--- a/apps/rahat-ui/src/sections/projects/aa-2/communicationLog/details/comms.logs.detail.page.tsx
+++ b/apps/rahat-ui/src/sections/projects/aa-2/communicationLog/details/comms.logs.detail.page.tsx
@@ -217,8 +217,9 @@ export default function CommsLogsDetailPage() {
     }
 
     return from === 'activities'
-      ? `/projects/aa/${projectID}/activities/${activityId}${backFrom ? `?from=${backFrom}` : ''
-      }`
+      ? `/projects/aa/${projectID}/activities/${activityId}${
+          backFrom ? `?from=${backFrom}` : ''
+        }`
       : `/projects/aa/${projectID}/communication-logs/details/${activityId}`;
   }, [from, projectID, activityId, tab, subTab, backFrom]);
 
@@ -401,7 +402,7 @@ export default function CommsLogsDetailPage() {
                 <div>
                   <p className="text-sm text-gray-500">Triggered Date</p>
                   <p className="font-medium">
-                    {dateFormat(logs?.sessionDetails?.createdAt)}
+                    {dateFormat(logs?.sessionDetails?.updatedAt)}
                   </p>
                 </div>
 
@@ -436,12 +437,13 @@ export default function CommsLogsDetailPage() {
                   </div>
 
                   <Badge
-                    className={`${logs?.sessionDetails?.status === 'COMPLETED'
-                      ? 'bg-green-100 text-green-600 hover:bg-green-100'
-                      : logs?.sessionDetails?.status === 'PENDING'
+                    className={`${
+                      logs?.sessionDetails?.status === 'COMPLETED'
+                        ? 'bg-green-100 text-green-600 hover:bg-green-100'
+                        : logs?.sessionDetails?.status === 'PENDING'
                         ? 'bg-yellow-100 text-yellow-600 hover:bg-yellow-100'
                         : 'bg-red-100 text-red-600 hover:bg-red-100'
-                      } rounded-full px-3`}
+                    } rounded-full px-3`}
                   >
                     {logs?.sessionDetails?.status}
                   </Badge>

--- a/apps/rahat-ui/src/sections/projects/aa-2/communicationLog/details/comms.logs.export.utils.ts
+++ b/apps/rahat-ui/src/sections/projects/aa-2/communicationLog/details/comms.logs.export.utils.ts
@@ -95,8 +95,8 @@ function buildRowMapper(logs: LogsData) {
     'Communication Title':
       logs?.communicationDetail?.communicationTitle || 'N/A',
     ...getTypeFields(log, logs),
-    'Triggered Date': logs?.sessionDetails?.createdAt
-      ? dateFormat(logs.sessionDetails.createdAt)
+    'Triggered Date': logs?.sessionDetails?.updatedAt
+      ? dateFormat(logs.sessionDetails.updatedAt)
       : 'N/A',
     'Created Date': log.createdAt ? dateFormat(log.createdAt) : 'N/A',
     'Updated Date': log.updatedAt ? dateFormat(log.updatedAt) : 'N/A',

--- a/apps/rahat-ui/src/sections/projects/aa-2/communicationLog/table/useCommsLogsTableColumns.tsx
+++ b/apps/rahat-ui/src/sections/projects/aa-2/communicationLog/table/useCommsLogsTableColumns.tsx
@@ -54,7 +54,7 @@ export default function useCommsLogsTableColumns(transportName: string) {
       cell: ({ row }) => {
         return (
           <div className="flex items-center space-x-2 gap-2">
-            {dateFormat(row?.original?.createdAt)}
+            {dateFormat(row?.original?.updatedAt)}
             {transportName === 'VOICE' && row?.original?.status === 'FAIL' && (
               <TooltipProvider>
                 <Tooltip>

--- a/apps/rahat-ui/src/sections/projects/aa/communication-logs/useCommsLogsTableColumns.tsx
+++ b/apps/rahat-ui/src/sections/projects/aa/communication-logs/useCommsLogsTableColumns.tsx
@@ -1,50 +1,47 @@
 import { ColumnDef } from '@tanstack/react-table';
 import { Badge } from '@rahat-ui/shadcn/src/components/ui/badge';
-import { BroadcastStatus } from "@rumsan/connect/src/types"
+import { BroadcastStatus } from '@rumsan/connect/src/types';
 
 export default function useCommsLogsTableColumns() {
   const columns: ColumnDef<any>[] = [
     {
       accessorKey: 'audience',
       header: 'Audience',
-      cell: ({ row }) => (
-        <div className="">{row?.original?.address}</div>
-      ),
+      cell: ({ row }) => <div className="">{row?.original?.address}</div>,
     },
     {
       accessorKey: 'status',
       header: 'Status',
       cell: ({ row }) => {
         return (
-          <Badge className={renderBadgeBg(row?.original?.status)}>{row?.original?.status}</Badge>
-        )
+          <Badge className={renderBadgeBg(row?.original?.status)}>
+            {row?.original?.status}
+          </Badge>
+        );
       },
     },
     {
       accessorKey: 'attempts',
       header: 'Attempts',
       cell: ({ row }) => {
-        return (
-          <div className='ml-8'>{row?.original?.attempts}</div>
-        )
+        return <div className="ml-8">{row?.original?.attempts}</div>;
       },
     },
     {
       accessorKey: 'timeStamp',
       header: 'Timestamp',
-      cell: ({ row }) => (
-        <div>{renderDateTime(row?.original?.createdAt)}</div>
-      ),
+      cell: ({ row }) => <div>{renderDateTime(row?.original?.createdAt)}</div>,
     },
     {
       accessorKey: 'duration',
       header: 'Duration',
-      cell: ({ row }) => <div>{row?.original?.disposition?.cdr?.billableseconds || 'N/A'}</div>,
+      cell: ({ row }) => (
+        <div>{row?.original?.disposition?.cdr?.billableseconds || 'N/A'}</div>
+      ),
     },
   ];
   return columns;
 }
-
 
 function renderDateTime(dateTime: string) {
   if (dateTime) {
@@ -53,18 +50,18 @@ function renderDateTime(dateTime: string) {
     const localeTime = d.toLocaleTimeString();
     return `${localeDate} ${localeTime}`;
   }
-  return 'N/A'
+  return 'N/A';
 }
 
 function renderBadgeBg(status: string) {
-  if(status === BroadcastStatus.FAIL){
-    return "bg-red-200"
+  if (status === BroadcastStatus.FAIL) {
+    return 'bg-red-200';
   }
-  if(status === BroadcastStatus.SUCCESS){
-    return "bg-green-200"
+  if (status === BroadcastStatus.SUCCESS) {
+    return 'bg-green-200';
   }
-  if(status === BroadcastStatus.PENDING){
-    return "bg-yellow-200"
+  if (status === BroadcastStatus.PENDING) {
+    return 'bg-yellow-200';
   }
-  return "bg-gray-200"
+  return 'bg-gray-200';
 }


### PR DESCRIPTION
## 🔗 Related Issue

https://github.com/rahataid/rahat-ui/issues/2375

- [x] Added issue link

## 📌 Description

- Updated the **Timestamp** column in the **Individual Voice Communication Logs** to display the recipient log's `updatedAt` value instead of `createdAt`.
- This ensures the timestamp reflects the most recent update to the communication record rather than the initial trigger time.
- The change allows users to accurately identify when the communication data was last modified or synchronized.

---

## ✅ Checklist

- [x] No `console.log` or debug code left
- [ ] Proper error handling implemented
- [ ] Loading states handled (if needed)
- [ ] API calls handled safely
- [x] No unnecessary code or comments
- [x] Self-reviewed code for logic, edge cases, and potential issues

---

## 🎯 Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] UI update
- [ ] Refactor
- [ ] Performance improvement

---

## 📸 Before / After

### Before

<img width="2878" height="1356" alt="image" src="https://github.com/user-attachments/assets/47148d05-b101-481d-b7cf-eb383f4e28cd" />

### After

<img width="1455" height="875" alt="image" src="https://github.com/user-attachments/assets/38d31d3d-a19f-4958-807e-fef75150058b" />

---

## 🧪 How to Test

1. Open **Communication Logs**.
2. Navigate to the **Individual Logs** tab and select a Voice communication.
3. Verify that the **Timestamp** column matches the `updatedAt` value returned by the API instead of `createdAt`.

---

## ⚠️ Notes for Reviewer

- This change only updates the timestamp source in the Individual Voice Communication Logs table.
- No API changes or other UI behavior were modified.