### PR TITLE
2454 redirect transaction hash as per chain settings

### DIFF
--- a/apps/rahat-ui/src/sections/projects/aa-2/payout/benefTransactionDetails/benefTransactionDetails.tsx
+++ b/apps/rahat-ui/src/sections/projects/aa-2/payout/benefTransactionDetails/benefTransactionDetails.tsx
@@ -174,11 +174,6 @@ export default function BeneficiaryTransactionLogDetails() {
               copyable
             />
             <InfoItem
-              label="Transaction Wallet ID"
-              value={data?.data?.info?.offrampWalletAddress}
-              copyable
-            />
-            <InfoItem
               label="Transaction Hash"
               value={data?.data?.txHash}
               link

--- a/apps/rahat-ui/src/sections/projects/aa-2/payout/benefTransactionDetails/infoItem.tsx
+++ b/apps/rahat-ui/src/sections/projects/aa-2/payout/benefTransactionDetails/infoItem.tsx
@@ -1,6 +1,9 @@
-import { useProjectSettingsStore, useProjectStore } from '@rahat-ui/query';
+import {
+  PROJECT_SETTINGS_KEYS,
+  useProjectSettingsStore,
+} from '@rahat-ui/query';
 import useCopy from 'apps/rahat-ui/src/hooks/useCopy';
-import { getStellarTxUrl } from 'apps/rahat-ui/src/utils/stellar';
+import { getExplorerUrl } from 'apps/rahat-ui/src/utils';
 import { Copy, CopyCheckIcon } from 'lucide-react';
 import { useParams } from 'next/navigation';
 
@@ -27,7 +30,12 @@ export default function InfoItem({
   const { settings } = useProjectSettingsStore((s) => ({
     settings: s.settings,
   }));
-  const project = useProjectStore((p) => p.singleProject);
+  const txUrl = getExplorerUrl({
+    chainSettings:
+      settings?.[projectId]?.[PROJECT_SETTINGS_KEYS.CHAIN_SETTINGS],
+    target: 'tx',
+    value,
+  });
 
   return (
     <div className="space-y-1 break-words">
@@ -37,7 +45,7 @@ export default function InfoItem({
           <>
             {link ? (
               <a
-                href={`https://sepolia.basescan.org/tx/${value}`}
+                href={txUrl || '#'}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-base text-blue-500 hover:underline cursor-pointer truncate w-24"

--- a/apps/rahat-ui/src/sections/projects/aa-2/vendor/columns/useInkindRedemptionColumn.tsx
+++ b/apps/rahat-ui/src/sections/projects/aa-2/vendor/columns/useInkindRedemptionColumn.tsx
@@ -1,4 +1,8 @@
-import { useUpdateVendorRedemptionStatus } from '@rahat-ui/query';
+import {
+  PROJECT_SETTINGS_KEYS,
+  useProjectSettingsStore,
+  useUpdateVendorRedemptionStatus,
+} from '@rahat-ui/query';
 import { ColumnDef, Row } from '@tanstack/react-table';
 import { InkindRedemptionData } from '../tabs/inkind.redemption.list';
 import { TruncatedCell } from '../../stakeholders/component/TruncatedCell';
@@ -10,12 +14,16 @@ import { DialogComponent } from 'apps/rahat-ui/src/components/dialog';
 import { UUID } from 'crypto';
 import { formatLabel } from '../../inkindManagement/components/inkind.allocation.list';
 import { INKIND_TYPE_LABELS } from '../../inkindManagement/schemas/inkind.validation';
+import { getExplorerUrl } from 'apps/rahat-ui/src/utils';
 
 export const useInkindRedemptionColumn = (
   id: UUID,
   showActions: boolean = true,
 ) => {
   const approveRedemptionStatus = useUpdateVendorRedemptionStatus();
+  const { settings } = useProjectSettingsStore((s) => ({
+    settings: s.settings,
+  }));
   const handleApproveClick = (row: Row<InkindRedemptionData>) => {
     approveRedemptionStatus.mutate({
       projectUUID: id,
@@ -44,13 +52,17 @@ export const useInkindRedemptionColumn = (
         if (!row.original?.transactionHash) {
           return <div>N/A</div>;
         }
+        const txUrl = getExplorerUrl({
+          chainSettings:
+            settings?.[id]?.[PROJECT_SETTINGS_KEYS.CHAIN_SETTINGS],
+          target: 'tx',
+          value: row.original?.transactionHash,
+        });
         return (
           <div className="flex flex-row">
             <div className="w-20 truncate">
               <a
-                href={`https://sepolia.basescan.org/tx/${row.getValue(
-                  'transactionHash',
-                )}`}
+                href={txUrl || '#'}
                 target="_blank"
                 rel="noopener noreferrer"
                 className=" text-blue-500 hover:underline cursor-pointer "

--- a/apps/rahat-ui/src/sections/projects/aa-2/vendor/table.columns.tsx
+++ b/apps/rahat-ui/src/sections/projects/aa-2/vendor/table.columns.tsx
@@ -1,4 +1,5 @@
 import {
+  PROJECT_SETTINGS_KEYS,
   TOKEN_TO_AMOUNT_MULTIPLIER,
   useProjectSettingsStore,
 } from '@rahat-ui/query';
@@ -12,6 +13,7 @@ import { PaginationTableName } from 'apps/rahat-ui/src/constants/pagination.tabl
 import { dateFormat } from 'apps/rahat-ui/src/utils/dateFormate';
 import { setPaginationToLocalStorage } from 'apps/rahat-ui/src/utils/prev.pagination.storage.dynamic';
 import { getAssetCode } from 'apps/rahat-ui/src/utils/stellar';
+import { getExplorerUrl } from 'apps/rahat-ui/src/utils';
 import { UUID } from 'crypto';
 import { Eye } from 'lucide-react';
 import TooltipComponent from 'apps/rahat-ui/src/components/tooltip';
@@ -182,13 +184,17 @@ export const useProjectVendorRedemptionTableColumns = () => {
         if (!row.original?.transactionHash) {
           return <div>N/A</div>;
         }
+        const txUrl = getExplorerUrl({
+          chainSettings:
+            settings?.[id]?.[PROJECT_SETTINGS_KEYS.CHAIN_SETTINGS],
+          target: 'tx',
+          value: row.original?.transactionHash,
+        });
         return (
           <div className="flex flex-row">
             <div className="w-20 truncate">
               <a
-                href={`https://sepolia.basescan.org/tx/${row.getValue(
-                  'transactionHash',
-                )}`}
+                href={txUrl || '#'}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-base text-blue-500 hover:underline cursor-pointer "


### PR DESCRIPTION
## 🔗 Related Issue

https://github.com/rahataid/rahat-ui/issues/2454

- [x] Added issue link

## 📌 Description

This PR fixes incorrect blockchain explorer links and updates the payout details UI.

- Changes made:
  - Updated the transaction hash link in the Payout Beneficiary Details page to redirect to the Stellar Explorer instead of the Sepolia Explorer.
  - Removed the Transaction Wallet ID field from the Payout Details UI as specified in the issue requirements.
  - Updated the transaction hash link in the Vendor Redemption table to use the Stellar Explorer.

---

## ✅ Checklist

- [x] No `console.log` or debug code left
- [ ] Proper error handling implemented
- [ ] Loading states handled (if needed)
- [ ] API calls handled safely
- [x] No unnecessary code or comments
- [x] Self-reviewed code for logic, edge cases, and potential issues

---

## 🎯 Type of Change

- [x] Bug fix
- [ ] New feature
- [x] UI update
- [ ] Refactor
- [ ] Performance improvement

---

## 📸 Before / After

### Before

<img width="1094" height="683" alt="image" src="https://github.com/user-attachments/assets/a1167e0d-7751-4da1-b348-0bd585d0543d" />
<img width="1112" height="685" alt="image" src="https://github.com/user-attachments/assets/cb39badc-a822-4286-91f5-bfab496d5042" />

### After

https://jam.dev/c/95cf9124-73b4-451a-bf18-93b31426543c
---

## 🧪 How to Test

1. Open the Payout Beneficiary Details page.
2. Click the transaction hash and verify it opens the Stellar Explorer.
3. Open the Vendor Redemption table and verify the transaction hash also opens the Stellar Explorer.
4. Verify that the Transaction Wallet ID is no longer displayed in the Payout Details section.

---

## ⚠️ Notes for Reviewer

<!-- Anything special reviewer should know -->

- Explorer links have been updated to match the Stellar network.
- UI has been updated according to the issue requirements.
