### PR TITLE
Implement server-sent events (SSE) for activities page with new constants and service updates

### DIFF
--- a/apps/rahat-ui/src/constants/sse.constants.ts
+++ b/apps/rahat-ui/src/constants/sse.constants.ts
@@ -1,4 +1,4 @@
-import { PHASE_QUERY_KEYS } from '@rahat-ui/query';
+import { ACTIVITY_QUERY_KEYS, PHASE_QUERY_KEYS } from '@rahat-ui/query';
 import { UUID } from 'crypto';
 
 export type EVENT =
@@ -7,7 +7,9 @@ export type EVENT =
   | 'phase.deleted'
   | 'beneficiaries.updated'
   | 'trigger.updated'
-  | 'trigger.created';
+  | 'trigger.created'
+  | 'activity.created'
+  | 'activity.updated';
 
 export const EVENT_QUERY_MAP: Record<
   string,
@@ -29,4 +31,14 @@ export const EVENT_QUERY_MAP: Record<
   'trigger.updated': (projectUuid) => [[PHASE_QUERY_KEYS.PHASE, projectUuid]],
 
   'trigger.created': (projectUuid) => [[PHASE_QUERY_KEYS.PHASE, projectUuid]],
+
+  'activity.created': (projectUuid) => [
+    [ACTIVITY_QUERY_KEYS.ACTIVITIES, projectUuid],
+  ],
+
+  'activity.updated': (projectUuid) => [
+    [ACTIVITY_QUERY_KEYS.ACTIVITIES, projectUuid],
+    [ACTIVITY_QUERY_KEYS.ACTIVITY, projectUuid],
+    [ACTIVITY_QUERY_KEYS.ACTIVITIES_HAVING_COMMS, projectUuid],
+  ],
 };

--- a/libs/query/src/lib/aa/activities/activities.constants.ts
+++ b/libs/query/src/lib/aa/activities/activities.constants.ts
@@ -1,0 +1,7 @@
+export const ACTIVITY_QUERY_KEYS = {
+  ACTIVITIES: 'activities',
+  ACTIVITY: 'activity',
+  ACTIVITIES_HAVING_COMMS: 'activitiesHavingComms',
+  CATEGORIES: 'categories',
+  ACTIVITY_TEMPLATES: 'activityTemplates',
+};

--- a/libs/query/src/lib/aa/activities/activities.service.ts
+++ b/libs/query/src/lib/aa/activities/activities.service.ts
@@ -3,6 +3,7 @@ import { useEffect } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useProjectAction, useProjectSettingsStore } from '../../projects';
 import { useActivitiesStore } from './activities.store';
+import { ACTIVITY_QUERY_KEYS } from './activities.constants';
 import { UUID } from 'crypto';
 import { useSwal } from 'libs/query/src/swal';
 import { PROJECT_SETTINGS_KEYS } from 'libs/query/src/config';
@@ -24,7 +25,7 @@ export const useActivitiesCategories = (uuid: UUID) => {
   }));
 
   const query = useQuery({
-    queryKey: ['categories', uuid],
+    queryKey: [ACTIVITY_QUERY_KEYS.CATEGORIES, uuid],
     queryFn: async () => {
       const mutate = await q.mutateAsync({
         uuid,
@@ -57,7 +58,9 @@ export const useAddActivityCategory = () => {
       return result.data;
     },
     onSuccess: (_, { uuid }) => {
-      queryClient.invalidateQueries({ queryKey: ['categories', uuid] });
+      queryClient.invalidateQueries({
+        queryKey: [ACTIVITY_QUERY_KEYS.CATEGORIES, uuid],
+      });
     },
   });
 };
@@ -73,7 +76,7 @@ export const useActivities = (uuid: UUID, payload: any) => {
   }));
 
   const query = useQuery({
-    queryKey: ['activities', uuid, payload],
+    queryKey: [ACTIVITY_QUERY_KEYS.ACTIVITIES, uuid, payload],
     queryFn: async () => {
       const mutate = await q.mutateAsync({
         uuid,
@@ -139,7 +142,7 @@ export const useActivitiesHavingComms = (uuid: UUID, payload: any) => {
     settings: state.settings,
   }));
   const query = useQuery({
-    queryKey: ['activitiesHavingComms', uuid, payload],
+    queryKey: [ACTIVITY_QUERY_KEYS.ACTIVITIES_HAVING_COMMS, uuid, payload],
     queryFn: async () => {
       const mutate = await q.mutateAsync({
         uuid,
@@ -193,7 +196,7 @@ export const useSingleActivity = (
   });
 
   const query = useQuery({
-    queryKey: ['activity', uuid, activityId],
+    queryKey: [ACTIVITY_QUERY_KEYS.ACTIVITY, uuid, activityId],
     queryFn: async () => {
       try {
         const mutate = await q.mutateAsync({
@@ -250,7 +253,7 @@ export const useCreateActivities = () => {
     },
     onSuccess: (data) => {
       q.reset();
-      qc.invalidateQueries({ queryKey: ['activities'] });
+      qc.invalidateQueries({ queryKey: [ACTIVITY_QUERY_KEYS.ACTIVITIES] });
       toast.fire({
         title: data?.data?.isTemplate
           ? 'Activity and its template added successfully'
@@ -338,7 +341,7 @@ export const useBulkAddActivities = () => {
     },
     onSuccess: () => {
       q.reset();
-      qc.invalidateQueries({ queryKey: ['activities'] });
+      qc.invalidateQueries({ queryKey: [ACTIVITY_QUERY_KEYS.ACTIVITIES] });
     },
     onError: (error: any) => {
       const errorMessage = error?.response?.data?.message || 'Error';
@@ -380,9 +383,11 @@ export const useUpdateActivities = () => {
     },
     onSuccess: () => {
       q.reset();
-      qc.invalidateQueries({ queryKey: ['activities'] });
-      qc.invalidateQueries({ queryKey: ['activity'] });
-      qc.invalidateQueries({ queryKey: ['activitiesHavingComms'] });
+      qc.invalidateQueries({ queryKey: [ACTIVITY_QUERY_KEYS.ACTIVITIES] });
+      qc.invalidateQueries({ queryKey: [ACTIVITY_QUERY_KEYS.ACTIVITY] });
+      qc.invalidateQueries({
+        queryKey: [ACTIVITY_QUERY_KEYS.ACTIVITIES_HAVING_COMMS],
+      });
       toast.fire({
         title: 'Activity updated successfully',
         icon: 'success',
@@ -430,8 +435,10 @@ export const useDeleteActivities = () => {
     },
     onSuccess: () => {
       q.reset();
-      qc.invalidateQueries({ queryKey: ['activities'] });
-      qc.invalidateQueries({ queryKey: ['activitiesHavingComms'] });
+      qc.invalidateQueries({ queryKey: [ACTIVITY_QUERY_KEYS.ACTIVITIES] });
+      qc.invalidateQueries({
+        queryKey: [ACTIVITY_QUERY_KEYS.ACTIVITIES_HAVING_COMMS],
+      });
       toast.fire({
         title: 'Activity removed successfully',
         icon: 'success',
@@ -478,7 +485,7 @@ export const useTriggerCommunication = () => {
 
     onSuccess: () => {
       q.reset();
-      qc.invalidateQueries({ queryKey: ['activity'] });
+      qc.invalidateQueries({ queryKey: [ACTIVITY_QUERY_KEYS.ACTIVITY] });
       toast.fire({
         title: 'Communication Trigger successfully',
         icon: 'success',
@@ -530,8 +537,8 @@ export const useUpdateActivityStatus = () => {
 
     onSuccess: () => {
       q.reset();
-      qc.invalidateQueries({ queryKey: ['activities'] });
-      qc.invalidateQueries({ queryKey: ['activity'] });
+      qc.invalidateQueries({ queryKey: [ACTIVITY_QUERY_KEYS.ACTIVITIES] });
+      qc.invalidateQueries({ queryKey: [ACTIVITY_QUERY_KEYS.ACTIVITY] });
       toast.fire({
         title: 'Status Updated',
         icon: 'success',
@@ -556,7 +563,7 @@ export const useActivityTemplates = (
   const q = useProjectAction();
 
   const query = useQuery({
-    queryKey: ['activityTemplates', uuid, filters],
+    queryKey: [ACTIVITY_QUERY_KEYS.ACTIVITY_TEMPLATES, uuid, filters],
     queryFn: async () => {
       const mutate = await q.mutateAsync({
         uuid,

--- a/libs/query/src/lib/aa/activities/index.ts
+++ b/libs/query/src/lib/aa/activities/index.ts
@@ -1,2 +1,3 @@
+export * from './activities.constants';
 export * from './activities.store';
 export * from './activities.service';


### PR DESCRIPTION

## 🔗 Related Issue

https://github.com/rahataid/rahat-ui/issues/2491

- [x] Added issue link

## 📌 Description

- Implemented Server-Sent Events (SSE) on the Activities page by following the existing implementation on the Phase page.

- Changes
  - Added SSE integration to the Activities page.
  - Subscribed to activity-related events for real-time updates.
  - Updated the Activities list automatically when events are received.
  - Reused the existing SSE implementation pattern from the Phase page for consistency.

---

## ✅ Checklist

- [x] No `console.log` or debug code left
- [ ] Proper error handling implemented
- [ ] Loading states handled (if needed)
- [x] API calls handled safely
- [x] No unnecessary code or comments
- [x] Self-reviewed code for logic, edge cases, and potential issues

---

## 🎯 Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] UI update
- [ ] Refactor
- [x] Performance improvement

---

## 📸 Before / After

### Before

## <!-- Add screenshots -->

### After

https://jam.dev/c/9fcccbd8-419e-48eb-970d-8c81aea54c4a

---

## 🧪 How to Test

1. Open the Activities page in two separate browser tabs.
2. In one tab, create, update, or delete an activity.
3. Verify that the other tab automatically reflects the change without requiring a page refresh.
4. Confirm the SSE connection remains active and updates continue to be received.

---

## ⚠️ Notes for Reviewer

- The SSE implementation follows the existing pattern used on the Phase page to ensure consistent real-time behavior across the application.
